### PR TITLE
[#5] OIDC 기반 카카오 로그인 구현하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,13 @@ dependencies {
 //	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/k_passs/backend/domain/bill/Bill.java
+++ b/src/main/java/com/k_passs/backend/domain/bill/Bill.java
@@ -3,7 +3,7 @@ package com.k_passs.backend.domain.bill;
 import com.k_passs.backend.domain.model.entity.BaseEntity;
 import com.k_passs.backend.domain.model.enums.BillCategory;
 import com.k_passs.backend.domain.model.enums.BillStatus;
-import com.k_passs.backend.domain.user.User;
+import com.k_passs.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/k_passs/backend/domain/user/Bookmark.java
+++ b/src/main/java/com/k_passs/backend/domain/user/Bookmark.java
@@ -2,6 +2,7 @@ package com.k_passs.backend.domain.user;
 
 import com.k_passs.backend.domain.model.entity.BaseEntity;
 import com.k_passs.backend.domain.tip.Tip;
+import com.k_passs.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/k_passs/backend/domain/user/KakaoProperties.java
+++ b/src/main/java/com/k_passs/backend/domain/user/KakaoProperties.java
@@ -1,0 +1,26 @@
+package com.k_passs.backend.domain.user;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@ConfigurationProperties(prefix = "kakao")
+@Component
+@Getter
+@Setter
+public class KakaoProperties {
+    private Client client;
+    private Redirect redirect;
+
+    @Getter @Setter
+    public static class Client {
+        private String id;
+        private String secret;
+    }
+
+    @Getter @Setter
+    public static class Redirect {
+        private String uri;
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/user/PointHistory.java
+++ b/src/main/java/com/k_passs/backend/domain/user/PointHistory.java
@@ -1,6 +1,7 @@
 package com.k_passs.backend.domain.user;
 
 import com.k_passs.backend.domain.model.entity.BaseEntity;
+import com.k_passs.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/k_passs/backend/domain/user/UserChallenge.java
+++ b/src/main/java/com/k_passs/backend/domain/user/UserChallenge.java
@@ -3,6 +3,7 @@ package com.k_passs.backend.domain.user;
 import com.k_passs.backend.domain.challenge.Challenge;
 import com.k_passs.backend.domain.model.entity.BaseEntity;
 import com.k_passs.backend.domain.model.enums.ChallengeStatus;
+import com.k_passs.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/k_passs/backend/domain/user/controller/KakaoAuthController.java
+++ b/src/main/java/com/k_passs/backend/domain/user/controller/KakaoAuthController.java
@@ -2,9 +2,11 @@ package com.k_passs.backend.domain.user.controller;
 
 
 import com.k_passs.backend.domain.user.util.JwtUtil;
+import com.k_passs.backend.global.error.code.status.ErrorStatus;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.http.HttpStatus;
 
 import java.util.Map;
 
@@ -12,33 +14,40 @@ import java.util.Map;
 @RequestMapping("/api/auth")
 public class KakaoAuthController {
 
+    // 클라이언트에서 카카오 액세스 토큰을 전달받아 로그인 처리
     @PostMapping("/kakao")
     public ResponseEntity<?> kakaoLogin(@RequestBody Map<String, String> body) {
+        // 클라이언트로부터 전달받은 액세스 토큰 추출
         String accessToken = body.get("accessToken");
 
-        // 1. 카카오 API 호출로 토큰 검증
+        // 1. 카카오 API 호출로 토큰 유효성 검증 및 사용자 정보 조회
         RestTemplate restTemplate = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", "Bearer " + accessToken);
+        headers.set("Authorization", "Bearer " + accessToken); // Bearer 토큰 형식으로 헤더 설정
         HttpEntity<String> entity = new HttpEntity<>(headers);
 
+        // 카카오 사용자 정보 API
         String url = "https://kapi.kakao.com/v2/user/me";
         ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.GET, entity, Map.class);
 
+        // 카카오 인증 실패 시 401 Unauthorized 반환
         if (response.getStatusCode() != HttpStatus.OK) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "카카오 인증 실패"));
+            return ResponseEntity
+                    .status(ErrorStatus._KAKAO_UNAUTHORIZED.getHttpStatus())
+                    .body(ErrorStatus._KAKAO_UNAUTHORIZED.getReasonHttpStatus());
         }
 
+        // 카카오 사용자 정보에서 ID 추출
         Map<String, Object> kakaoUser = response.getBody();
         String kakaoId = String.valueOf(kakaoUser.get("id"));
 
-        // 실제로는 UserRepository에서 findByKakaoId() 같은 로직 필요
-        boolean isNewUser = false; // 새 사용자라면 회원가입 처리
+        // TODO: 실제 서비스에서는 UserRepository 등을 이용한 사용자 조회 및 회원가입 로직 필요
+        boolean isNewUser = false; // 기본값으로 false 설정 (임시)
 
-        // 3. JWT 발급
+        // 3. JWT 발급 (사용자 식별용)
         String jwt = JwtUtil.generateToken(kakaoId);
 
-        // 4. JSON 응답 반환
+        // 4. 클라이언트에 JWT, 사용자 신규 여부, 카카오 ID를 포함한 JSON 응답 반환
         return ResponseEntity.ok(Map.of(
                 "jwt", jwt,
                 "isNewUser", isNewUser,

--- a/src/main/java/com/k_passs/backend/domain/user/controller/KakaoAuthController.java
+++ b/src/main/java/com/k_passs/backend/domain/user/controller/KakaoAuthController.java
@@ -1,0 +1,48 @@
+package com.k_passs.backend.domain.user.controller;
+
+
+import com.k_passs.backend.domain.user.util.JwtUtil;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth")
+public class KakaoAuthController {
+
+    @PostMapping("/kakao")
+    public ResponseEntity<?> kakaoLogin(@RequestBody Map<String, String> body) {
+        String accessToken = body.get("accessToken");
+
+        // 1. 카카오 API 호출로 토큰 검증
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        String url = "https://kapi.kakao.com/v2/user/me";
+        ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.GET, entity, Map.class);
+
+        if (response.getStatusCode() != HttpStatus.OK) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "카카오 인증 실패"));
+        }
+
+        Map<String, Object> kakaoUser = response.getBody();
+        String kakaoId = String.valueOf(kakaoUser.get("id"));
+
+        // 실제로는 UserRepository에서 findByKakaoId() 같은 로직 필요
+        boolean isNewUser = false; // 새 사용자라면 회원가입 처리
+
+        // 3. JWT 발급
+        String jwt = JwtUtil.generateToken(kakaoId);
+
+        // 4. JSON 응답 반환
+        return ResponseEntity.ok(Map.of(
+                "jwt", jwt,
+                "isNewUser", isNewUser,
+                "kakaoId", kakaoId
+        ));
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/k_passs/backend/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.k_passs.backend.domain.user.controller;
 
 import com.k_passs.backend.domain.user.entity.User;
+import com.k_passs.backend.global.error.code.status.ErrorStatus;
 import com.k_passs.backend.global.oauth2.CustomOAuth2User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -14,16 +15,22 @@ import org.springframework.http.ResponseEntity;
 @RequiredArgsConstructor
 public class UserController {
 
+    // 현재 로그인한 사용자 정보를 조회하는 API
     @GetMapping("/me")
     public ResponseEntity<?> getMyInfo(@AuthenticationPrincipal CustomOAuth2User user,
                                        @RequestHeader(value = "Authorization", required = false) String authHeader) {
 
-        System.out.println("📥 Authorization 헤더 값: " + authHeader);
+        // 요청 헤더에 포함된 Authorization 값을 콘솔에 출력 (디버깅 용도)
+        System.out.println("Authorization 헤더 값: " + authHeader);
 
+        // 인증된 사용자가 없는 경우 UNAUTHORIZED 상태 코드 반환
         if (user == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유저 인증 실패");
+            return ResponseEntity
+                    .status(ErrorStatus._USER_UNAUTHORIZED.getHttpStatus())
+                    .body(ErrorStatus._USER_UNAUTHORIZED.getReasonHttpStatus());
         }
 
+        // 인증된 사용자의 정보를 반환
         return ResponseEntity.ok(user.getUser());
     }
 }

--- a/src/main/java/com/k_passs/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/k_passs/backend/domain/user/controller/UserController.java
@@ -1,0 +1,29 @@
+package com.k_passs.backend.domain.user.controller;
+
+import com.k_passs.backend.domain.user.entity.User;
+import com.k_passs.backend.global.oauth2.CustomOAuth2User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import org.springframework.http.ResponseEntity;
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    @GetMapping("/me")
+    public ResponseEntity<?> getMyInfo(@AuthenticationPrincipal CustomOAuth2User user,
+                                       @RequestHeader(value = "Authorization", required = false) String authHeader) {
+
+        System.out.println("📥 Authorization 헤더 값: " + authHeader);
+
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유저 인증 실패");
+        }
+
+        return ResponseEntity.ok(user.getUser());
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/user/entity/User.java
+++ b/src/main/java/com/k_passs/backend/domain/user/entity/User.java
@@ -1,19 +1,20 @@
-package com.k_passs.backend.domain.user;
+package com.k_passs.backend.domain.user.entity;
 
 import com.k_passs.backend.domain.bill.Bill;
 import com.k_passs.backend.domain.model.entity.BaseEntity;
+import com.k_passs.backend.domain.user.PointHistory;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "users") // DB 테이블명을 명시
+@Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class User extends BaseEntity {
 
     @Id
@@ -30,13 +31,11 @@ public class User extends BaseEntity {
     private String profileImageUrl;
 
     @Column
-    private Long point; // int보다 큰 값을 가질 수 있으므로 Long 타입 사용
+    private Long point;
 
-    // User는 여러 Bill을 가질 수 있음 (1:N 관계)
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Bill> bills = new ArrayList<>();
 
-    // User는 여러 PointHistory를 가질 수 있음 (1:N 관계)
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<PointHistory> pointHistories = new ArrayList<>();
 }

--- a/src/main/java/com/k_passs/backend/domain/user/repogitory/UserRepository.java
+++ b/src/main/java/com/k_passs/backend/domain/user/repogitory/UserRepository.java
@@ -1,0 +1,10 @@
+package com.k_passs.backend.domain.user.repogitory;
+
+import com.k_passs.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/k_passs/backend/domain/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/k_passs/backend/domain/user/service/CustomOAuth2UserService.java
@@ -1,0 +1,41 @@
+package com.k_passs.backend.domain.user.service;
+
+import com.k_passs.backend.domain.user.entity.User;
+import com.k_passs.backend.domain.user.repogitory.UserRepository;
+import com.k_passs.backend.global.oauth2.CustomOAuth2User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest request) {
+        OAuth2User oAuth2User = super.loadUser(request);
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        String email = (String) kakaoAccount.get("email");
+        String nickname = (String) profile.get("nickname");
+        String profileImageUrl = (String) profile.get("profile_image_url");
+
+        User user = userRepository.findByEmail(email)
+                .orElseGet(() -> userRepository.save(User.builder()
+                        .email(email)
+                        .nickname(nickname)
+                        .profileImageUrl(profileImageUrl)
+                        .build()));
+
+        return new CustomOAuth2User(user);
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/k_passs/backend/domain/user/service/CustomOAuth2UserService.java
@@ -17,18 +17,23 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final UserRepository userRepository;
 
+    // OAuth2 로그인 후 사용자 정보를 불러오는 메서드
     @Override
     public OAuth2User loadUser(OAuth2UserRequest request) {
+        // 기본 구현을 통해 OAuth2 사용자 정보 조회
         OAuth2User oAuth2User = super.loadUser(request);
         Map<String, Object> attributes = oAuth2User.getAttributes();
 
+        // 카카오 계정 정보 추출
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
         Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
 
+        // 이메일, 닉네임, 프로필 이미지 추출
         String email = (String) kakaoAccount.get("email");
         String nickname = (String) profile.get("nickname");
         String profileImageUrl = (String) profile.get("profile_image_url");
 
+        // 이메일로 기존 사용자 조회, 없으면 새로 저장
         User user = userRepository.findByEmail(email)
                 .orElseGet(() -> userRepository.save(User.builder()
                         .email(email)
@@ -36,6 +41,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                         .profileImageUrl(profileImageUrl)
                         .build()));
 
+        // 사용자 정보를 기반으로 CustomOAuth2User 반환
         return new CustomOAuth2User(user);
     }
 }

--- a/src/main/java/com/k_passs/backend/domain/user/util/JwtUtil.java
+++ b/src/main/java/com/k_passs/backend/domain/user/util/JwtUtil.java
@@ -7,9 +7,13 @@ import java.security.Key;
 import java.util.Date;
 
 public class JwtUtil {
+    // JWT 서명을 위한 비밀 키 생성
     private static final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+
+    // 토큰 만료 시간 설정 (1시간)
     private static final long EXPIRATION_TIME = 1000 * 60 * 60; // 1시간
 
+    // 주어진 사용자 ID를 기반으로 JWT 토큰 생성
     public static String generateToken(String userId) {
         return Jwts.builder()
                 .setSubject(userId)
@@ -18,6 +22,7 @@ public class JwtUtil {
                 .compact();
     }
 
+    // 전달받은 JWT 토큰을 검증하고 사용자 ID(subject)를 추출
     public static String validateAndGetUserId(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(key)

--- a/src/main/java/com/k_passs/backend/domain/user/util/JwtUtil.java
+++ b/src/main/java/com/k_passs/backend/domain/user/util/JwtUtil.java
@@ -1,0 +1,29 @@
+package com.k_passs.backend.domain.user.util;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+
+public class JwtUtil {
+    private static final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+    private static final long EXPIRATION_TIME = 1000 * 60 * 60; // 1시간
+
+    public static String generateToken(String userId) {
+        return Jwts.builder()
+                .setSubject(userId)
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+                .signWith(key)
+                .compact();
+    }
+
+    public static String validateAndGetUserId(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+}

--- a/src/main/java/com/k_passs/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/k_passs/backend/global/config/SecurityConfig.java
@@ -1,0 +1,54 @@
+package com.k_passs.backend.global.config;
+
+import com.k_passs.backend.domain.user.service.CustomOAuth2UserService;
+import com.k_passs.backend.global.oauth2.OAuth2SuccessHandler;
+import com.k_passs.backend.global.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .cors(cors -> {})
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .exceptionHandling(exception ->
+                        exception.authenticationEntryPoint((request, response, authException) -> {
+                            response.setContentType("application/json");
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            response.getWriter().write("{\"error\": \"Unauthorized\"}");
+                        })
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo ->
+                                userInfo.userService(customOAuth2UserService)
+                        )
+                        .successHandler(oAuth2SuccessHandler)
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/k_passs/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/k_passs/backend/global/config/SecurityConfig.java
@@ -13,15 +13,24 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    // 사용자 정의 OAuth2UserService, 로그인 성공 핸들러, JWT 필터 의존성 주입
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
+    // 보안 설정 필터 체인 등록
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
@@ -42,13 +51,28 @@ public class SecurityConfig {
                         })
                 )
                 .oauth2Login(oauth2 -> oauth2
-                        .userInfoEndpoint(userInfo ->
-                                userInfo.userService(customOAuth2UserService)
+                                .userInfoEndpoint(userInfoEndpointConfig ->
+                                        userInfoEndpointConfig.userService(customOAuth2UserService)
                         )
                         .successHandler(oAuth2SuccessHandler)
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    // CORS 설정을 Bean으로 등록
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("*")); // 개발용: 모든 origin 허용
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*")); // 모든 헤더 허용
+        config.setExposedHeaders(List.of("Authorization")); // 클라이언트가 Authorization 헤더를 읽을 수 있게 허용
+        config.setAllowCredentials(true); // 필요한 경우만 true
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }

--- a/src/main/java/com/k_passs/backend/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/k_passs/backend/global/error/code/status/ErrorStatus.java
@@ -14,7 +14,12 @@ public enum ErrorStatus implements BaseErrorCode {
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    ///  auth 에러
+    _KAKAO_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH401", "카카오 인증 실패"),
+    _USER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "유저 인증 실패")
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/k_passs/backend/global/jwt/JwtProvider.java
+++ b/src/main/java/com/k_passs/backend/global/jwt/JwtProvider.java
@@ -7,7 +7,9 @@ import org.springframework.stereotype.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.util.Base64;
 import java.util.Date;
 
 @Component
@@ -15,18 +17,23 @@ public class JwtProvider {
 
     private static final Logger log = LoggerFactory.getLogger(JwtProvider.class);
 
+    // JWT 서명을 위한 키
     private final Key key;
 
+    // JWT 유효 시간: 24시간
     private static final long EXPIRATION_MS = 1000 * 60 * 60 * 24; // 24시간
 
     public JwtProvider(@Value("${jwt.secret}") String secretKey) {
-        this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
 
         // 환경 변수로부터 읽어온 secretKey 로그 출력
-        log.info("🔐 Loaded JWT secret key: {}", secretKey);
+        log.info("Loaded JWT secret key: {}", secretKey);
     }
 
+    // JWT 토큰 생성 메서드
     public String createToken(Long userId) {
+        log.info("JWT 생성 중! userId: {}", userId);
+        log.info("JWT 생성에 사용된 secret key: {}", Base64.getEncoder().encodeToString(key.getEncoded()));
         Date now = new Date();
         Date expiry = new Date(now.getTime() + EXPIRATION_MS);
 
@@ -38,6 +45,7 @@ public class JwtProvider {
                 .compact();
     }
 
+    // JWT 토큰에서 사용자 ID 추출
     public Long getUserId(String token) {
         Claims claims = Jwts.parserBuilder()
                 .setSigningKey(key)
@@ -47,12 +55,14 @@ public class JwtProvider {
         return Long.valueOf(claims.getSubject());
     }
 
+    // JWT 유효성 검증 메서드
     public boolean validateToken(String token) {
         try {
+            log.info("JWT 검증에 사용된 secret key: {}", Base64.getEncoder().encodeToString(key.getEncoded()));
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         } catch (JwtException | IllegalArgumentException e) {
-            log.warn("❌ Invalid JWT: {}", e.getMessage());
+            log.warn("Invalid JWT: {}", e.getMessage());
             return false;
         }
     }

--- a/src/main/java/com/k_passs/backend/global/jwt/JwtProvider.java
+++ b/src/main/java/com/k_passs/backend/global/jwt/JwtProvider.java
@@ -1,0 +1,59 @@
+package com.k_passs.backend.global.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtProvider.class);
+
+    private final Key key;
+
+    private static final long EXPIRATION_MS = 1000 * 60 * 60 * 24; // 24시간
+
+    public JwtProvider(@Value("${jwt.secret}") String secretKey) {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+
+        // 환경 변수로부터 읽어온 secretKey 로그 출력
+        log.info("🔐 Loaded JWT secret key: {}", secretKey);
+    }
+
+    public String createToken(Long userId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + EXPIRATION_MS);
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Long getUserId(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return Long.valueOf(claims.getSubject());
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("❌ Invalid JWT: {}", e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/k_passs/backend/global/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/k_passs/backend/global/oauth2/CustomOAuth2User.java
@@ -1,0 +1,36 @@
+package com.k_passs.backend.global.oauth2;
+
+import com.k_passs.backend.domain.user.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class CustomOAuth2User implements OAuth2User {
+
+    private final User user;
+
+    public CustomOAuth2User(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return Map.of(); // 필요 없을 경우 비워도 됨
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(user.getId());
+    }
+}

--- a/src/main/java/com/k_passs/backend/global/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/k_passs/backend/global/oauth2/OAuth2SuccessHandler.java
@@ -29,4 +29,14 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         response.setCharacterEncoding("UTF-8");
         response.getWriter().write("{\"token\": \"" + jwt + "\"}");
     }
+//@Override
+//public void onAuthenticationSuccess(HttpServletRequest request,
+//                                    HttpServletResponse response,
+//                                    Authentication authentication) throws IOException {
+//    CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+//    String jwt = jwtProvider.createToken(oAuth2User.getUser().getId());
+//
+//    // ✅ 로그인 성공 후 앱으로 리디렉션 (딥링크)
+//    response.sendRedirect("myapp://oauth/callback?token=" + jwt);
+//}
 }

--- a/src/main/java/com/k_passs/backend/global/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/k_passs/backend/global/oauth2/OAuth2SuccessHandler.java
@@ -1,0 +1,32 @@
+package com.k_passs.backend.global.oauth2;
+
+import com.k_passs.backend.global.jwt.JwtProvider;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+        String jwt = jwtProvider.createToken(oAuth2User.getUser().getId());
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write("{\"token\": \"" + jwt + "\"}");
+    }
+}

--- a/src/main/java/com/k_passs/backend/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/k_passs/backend/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,64 @@
+package com.k_passs.backend.global.security;
+
+import com.k_passs.backend.domain.user.entity.User;
+import com.k_passs.backend.domain.user.repogitory.UserRepository;
+import com.k_passs.backend.global.jwt.JwtProvider;
+import com.k_passs.backend.global.oauth2.CustomOAuth2User;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        System.out.println("🔐 JwtAuthenticationFilter 작동 시작");
+
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            System.out.println("🪪 받은 토큰: " + token);
+
+            if (jwtProvider.validateToken(token)) {
+                Long userId = jwtProvider.getUserId(token);
+                System.out.println("✅ 토큰 유효, userId: " + userId);
+
+                User user = userRepository.findById(userId).orElse(null);
+                if (user != null) {
+                    CustomOAuth2User principal = new CustomOAuth2User(user);
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+
+                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                    System.out.println("🔐 SecurityContext에 인증 저장 완료");
+                } else {
+                    System.out.println("❌ 유저 없음");
+                }
+            } else {
+                System.out.println("❌ 유효하지 않은 JWT");
+            }
+        } else {
+            System.out.println("❌ Authorization 헤더 없음 또는 형식 오류");
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/k_passs/backend/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/k_passs/backend/global/security/JwtAuthenticationFilter.java
@@ -24,41 +24,51 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
 
+    // 매 요청마다 JWT 유효성 검증 및 인증 정보를 SecurityContext에 설정
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
 
-        System.out.println("🔐 JwtAuthenticationFilter 작동 시작");
+        System.out.println("JwtAuthenticationFilter 작동 시작");
 
+        // Authorization 헤더에서 토큰 추출
         String authHeader = request.getHeader("Authorization");
-        if (authHeader != null && authHeader.startsWith("Bearer ")) {
-            String token = authHeader.substring(7);
-            System.out.println("🪪 받은 토큰: " + token);
+        System.out.println("Authorization 헤더 수신값: [" + authHeader + "]");
 
+        // 헤더가 존재하고 Bearer 토큰 형식인지 확인
+        if (authHeader != null && authHeader.trim().toLowerCase().startsWith("bearer ")) {
+            String token = authHeader.trim().substring(7).trim();
+            System.out.println("받은 토큰: " + token);
+
+            // 토큰 유효성 검증
             if (jwtProvider.validateToken(token)) {
                 Long userId = jwtProvider.getUserId(token);
-                System.out.println("✅ 토큰 유효, userId: " + userId);
+                System.out.println("토큰 유효, userId: " + userId);
 
+                // DB에서 사용자 조회
                 User user = userRepository.findById(userId).orElse(null);
                 if (user != null) {
+                    // CustomOAuth2User 생성 및 Spring Security 인증 객체 구성
                     CustomOAuth2User principal = new CustomOAuth2User(user);
                     UsernamePasswordAuthenticationToken authentication =
                             new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
 
+                    // 인증 세부 정보 설정 및 SecurityContext에 저장
                     authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                     SecurityContextHolder.getContext().setAuthentication(authentication);
-                    System.out.println("🔐 SecurityContext에 인증 저장 완료");
+                    System.out.println("SecurityContext에 인증 저장 완료");
                 } else {
-                    System.out.println("❌ 유저 없음");
+                    System.out.println("유저 없음");
                 }
             } else {
-                System.out.println("❌ 유효하지 않은 JWT");
+                System.out.println("유효하지 않은 JWT");
             }
         } else {
-            System.out.println("❌ Authorization 헤더 없음 또는 형식 오류");
+            System.out.println("Authorization 헤더 없음 또는 형식 오류");
         }
 
+        // 다음 필터로 요청 전달
         filterChain.doFilter(request, response);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    username: root
-    password:
-    url: jdbc:mysql://localhost:3306/billow_db #테스트용 로컬 db
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    url: ${DB_URL}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
@@ -16,10 +16,38 @@ spring:
         use_sql_comments: true
         default_batch_fetch_size: 1000
 
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            scope: profile_nickname, profile_image, account_email
+            client-name: Kakao
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            client-authentication-method: client_secret_post
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
   servlet:
     multipart:
       max-file-size: 100MB
       max-request-size: 100MB
+
+kakao:
+  client:
+    id: ${KAKAO_CLIENT_ID}
+    secret: ${KAKAO_CLIENT_SECRET}
+  redirect:
+    uri: ${KAKAO_REDIRECT_URI}
+
+jwt:
+  secret: ${JWT_SECRET_KEY}
 
 logging:
   level:


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #5 

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 카카오 OIDC 로그인 연동 및 JWT 인증 기능을 구현하였습니다.(카카오 로그인(OAuth2) 연동과 JWT 기반 인증 처리를 구현)
- 카카오 로그인 성공 시 사용자 정보를 기반으로 JWT를 발급하며, 요청 시 Authorization 헤더의 Bearer 토큰을 검증하여 인증 처리합니다.
- 모든 민감한 정보들은 환경 변수로 처리를 했습니다.

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- 처음에는 iOS 버전으로 테스트를 진행하려 했으나, 프론트에서의 JWT 헤더 전송 처리가 미완성이라 적용되지 않아, 단순 테스트의 개념이었기에  Postman을 통해 백엔드 기능을 테스트하였습니다.