### PR TITLE
[#7] 북마크 및 꿀팁 api 구현

### DIFF
--- a/src/main/java/com/k_passs/backend/domain/bookmark/api/BookmarkRestController.java
+++ b/src/main/java/com/k_passs/backend/domain/bookmark/api/BookmarkRestController.java
@@ -7,7 +7,6 @@ import com.k_passs.backend.global.common.response.BaseResponse;
 import com.k_passs.backend.global.error.code.status.SuccessStatus;
 import com.k_passs.backend.global.oauth2.CustomOAuth2User;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;

--- a/src/main/java/com/k_passs/backend/domain/bookmark/api/BookmarkRestController.java
+++ b/src/main/java/com/k_passs/backend/domain/bookmark/api/BookmarkRestController.java
@@ -1,0 +1,47 @@
+package com.k_passs.backend.domain.bookmark.api;
+
+import com.k_passs.backend.domain.bookmark.dto.BookmarkRequestDTO;
+import com.k_passs.backend.domain.bookmark.dto.BookmarkResponseDTO;
+import com.k_passs.backend.domain.bookmark.service.BookmarkService;
+import com.k_passs.backend.global.common.response.BaseResponse;
+import com.k_passs.backend.global.error.code.status.SuccessStatus;
+import com.k_passs.backend.global.oauth2.CustomOAuth2User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/bookmark")
+@Validated
+public class BookmarkRestController {
+
+    private final BookmarkService bookMarkService;
+
+    ///  북마크를 표시하면 보내야하니까?
+    @PostMapping("/bookmark")
+    @Operation(summary = "특정 꿀팁에 북마크 요청 또는 취소하는 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "BOOKMARK_200", description = "북마크 상태가 성공적으로 변경되었습니다.")
+    })
+    public BaseResponse<BookmarkResponseDTO.BookmarkResult> bookmark(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @RequestBody @Valid BookmarkRequestDTO.Bookmark request
+    ) {
+        BookmarkResponseDTO.BookmarkResult result =
+                bookMarkService.updateBookmarkStatus(
+                        user.getUser(),                          // CustomOAuth2User → User
+                        request.getTipId(),                      // Long
+                        request.getIsBookmarked()                // boolean
+                );
+
+        return BaseResponse.onSuccess(SuccessStatus.BOOKMARK_STATUS_CHANGED, result);
+    }
+
+}

--- a/src/main/java/com/k_passs/backend/domain/bookmark/api/BookmarkRestController.java
+++ b/src/main/java/com/k_passs/backend/domain/bookmark/api/BookmarkRestController.java
@@ -1,8 +1,9 @@
 package com.k_passs.backend.domain.bookmark.api;
 
 import com.k_passs.backend.domain.bookmark.dto.BookmarkRequestDTO;
-import com.k_passs.backend.domain.bookmark.dto.BookmarkResponseDTO;
 import com.k_passs.backend.domain.bookmark.service.BookmarkService;
+import com.k_passs.backend.domain.user.entity.User;
+import com.k_passs.backend.domain.user.service.UserService;
 import com.k_passs.backend.global.common.response.BaseResponse;
 import com.k_passs.backend.global.error.code.status.SuccessStatus;
 import com.k_passs.backend.global.oauth2.CustomOAuth2User;
@@ -22,25 +23,25 @@ import org.springframework.web.bind.annotation.*;
 public class BookmarkRestController {
 
     private final BookmarkService bookMarkService;
+    private final UserService userService;
 
-    ///  북마크를 표시하면 보내야하니까?
     @PostMapping("")
     @Operation(summary = "특정 꿀팁에 북마크 요청 또는 취소하는 API")
     @ApiResponses({
             @ApiResponse(responseCode = "BOOKMARK_200", description = "북마크 상태가 성공적으로 변경되었습니다.")
     })
-    public BaseResponse<BookmarkResponseDTO.BookmarkResult> bookmark(
+    public BaseResponse<String> bookmark(
             @AuthenticationPrincipal CustomOAuth2User user,
             @RequestBody @Valid BookmarkRequestDTO.Bookmark request
     ) {
-        BookmarkResponseDTO.BookmarkResult result =
-                bookMarkService.updateBookmarkStatus(
-                        user.getUser(),
-                        request.getTipId(),
-                        request.getIsBookmarked()
-                );
+        if (user == null || user.getUser() == null) {
+            // 테스트용 더미 유저 생성
+            User dummyUser = userService.getUserById(1L); // 테스트용 ID
+            bookMarkService.updateBookmarkStatus(dummyUser, request);
+            return BaseResponse.onSuccess(SuccessStatus.BOOKMARK_STATUS_CHANGED, "북마크 상태가 변경되었습니다.");
+        }
 
-        return BaseResponse.onSuccess(SuccessStatus.BOOKMARK_STATUS_CHANGED, result);
+        bookMarkService.updateBookmarkStatus(user.getUser(), request);
+        return BaseResponse.onSuccess(SuccessStatus.BOOKMARK_STATUS_CHANGED, "북마크 상태가 변경되었습니다.");
     }
-
 }

--- a/src/main/java/com/k_passs/backend/domain/bookmark/api/BookmarkRestController.java
+++ b/src/main/java/com/k_passs/backend/domain/bookmark/api/BookmarkRestController.java
@@ -25,7 +25,7 @@ public class BookmarkRestController {
     private final BookmarkService bookMarkService;
 
     ///  북마크를 표시하면 보내야하니까?
-    @PostMapping("/bookmark")
+    @PostMapping("")
     @Operation(summary = "특정 꿀팁에 북마크 요청 또는 취소하는 API")
     @ApiResponses({
             @ApiResponse(responseCode = "BOOKMARK_200", description = "북마크 상태가 성공적으로 변경되었습니다.")
@@ -36,9 +36,9 @@ public class BookmarkRestController {
     ) {
         BookmarkResponseDTO.BookmarkResult result =
                 bookMarkService.updateBookmarkStatus(
-                        user.getUser(),                          // CustomOAuth2User → User
-                        request.getTipId(),                      // Long
-                        request.getIsBookmarked()                // boolean
+                        user.getUser(),
+                        request.getTipId(),
+                        request.getIsBookmarked()
                 );
 
         return BaseResponse.onSuccess(SuccessStatus.BOOKMARK_STATUS_CHANGED, result);

--- a/src/main/java/com/k_passs/backend/domain/bookmark/dto/BookmarkRequestDTO.java
+++ b/src/main/java/com/k_passs/backend/domain/bookmark/dto/BookmarkRequestDTO.java
@@ -1,0 +1,22 @@
+package com.k_passs.backend.domain.bookmark.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BookmarkRequestDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static  class Bookmark {
+        @NotNull
+        private Long tipId;
+
+        @NotNull
+        private Boolean isBookmarked;
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/bookmark/dto/BookmarkResponseDTO.java
+++ b/src/main/java/com/k_passs/backend/domain/bookmark/dto/BookmarkResponseDTO.java
@@ -1,0 +1,17 @@
+package com.k_passs.backend.domain.bookmark.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BookmarkResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static  class BookmarkResult {
+        private Long tipId;
+        private boolean isBookmarked;
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/k_passs/backend/domain/bookmark/entity/Bookmark.java
@@ -1,7 +1,7 @@
-package com.k_passs.backend.domain.user;
+package com.k_passs.backend.domain.bookmark.entity;
 
 import com.k_passs.backend.domain.model.entity.BaseEntity;
-import com.k_passs.backend.domain.tip.Tip;
+import com.k_passs.backend.domain.tip.entity.Tip;
 import com.k_passs.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -25,4 +25,9 @@ public class Bookmark extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tip_id", nullable = false)
     private Tip tip;
+
+    public Bookmark(User user, Tip tip) {
+        this.user = user;
+        this.tip = tip;
+    }
 }

--- a/src/main/java/com/k_passs/backend/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/k_passs/backend/domain/bookmark/repository/BookmarkRepository.java
@@ -1,0 +1,14 @@
+package com.k_passs.backend.domain.bookmark.repository;
+
+import com.k_passs.backend.domain.bookmark.entity.Bookmark;
+import com.k_passs.backend.domain.tip.entity.Tip;
+import com.k_passs.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+    boolean existsByUserAndTip(User user, Tip tip);
+    void deleteByUserAndTip(User user, Tip tip);
+    List<Bookmark> findByUser(User user);
+}

--- a/src/main/java/com/k_passs/backend/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/k_passs/backend/domain/bookmark/service/BookmarkService.java
@@ -1,0 +1,11 @@
+package com.k_passs.backend.domain.bookmark.service;
+
+import com.k_passs.backend.domain.bookmark.dto.BookmarkResponseDTO;
+import com.k_passs.backend.domain.tip.entity.Tip;
+import com.k_passs.backend.domain.user.entity.User;
+
+import java.util.List;
+
+public interface BookmarkService {
+    BookmarkResponseDTO.BookmarkResult updateBookmarkStatus(User user, Long tipId, boolean isBookmarked);
+}

--- a/src/main/java/com/k_passs/backend/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/k_passs/backend/domain/bookmark/service/BookmarkService.java
@@ -1,11 +1,8 @@
 package com.k_passs.backend.domain.bookmark.service;
 
-import com.k_passs.backend.domain.bookmark.dto.BookmarkResponseDTO;
-import com.k_passs.backend.domain.tip.entity.Tip;
+import com.k_passs.backend.domain.bookmark.dto.BookmarkRequestDTO;
 import com.k_passs.backend.domain.user.entity.User;
 
-import java.util.List;
-
 public interface BookmarkService {
-    BookmarkResponseDTO.BookmarkResult updateBookmarkStatus(User user, Long tipId, boolean isBookmarked);
+    void updateBookmarkStatus(User user, BookmarkRequestDTO.Bookmark bookmarkRequestDTO);
 }

--- a/src/main/java/com/k_passs/backend/domain/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/k_passs/backend/domain/bookmark/service/BookmarkServiceImpl.java
@@ -1,6 +1,6 @@
 package com.k_passs.backend.domain.bookmark.service;
 
-import com.k_passs.backend.domain.bookmark.dto.BookmarkResponseDTO;
+import com.k_passs.backend.domain.bookmark.dto.BookmarkRequestDTO;
 import com.k_passs.backend.domain.bookmark.entity.Bookmark;
 import com.k_passs.backend.domain.bookmark.repository.BookmarkRepository;
 import com.k_passs.backend.domain.tip.entity.Tip;
@@ -8,8 +8,7 @@ import com.k_passs.backend.domain.tip.repository.TipRepository;
 import com.k_passs.backend.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,8 +17,13 @@ public class BookmarkServiceImpl implements BookmarkService {
     private final BookmarkRepository bookmarkRepository;
     private final TipRepository tipRepository;
 
+    // 북마크 상태 변환
     @Override
-    public BookmarkResponseDTO.BookmarkResult updateBookmarkStatus(User user, Long tipId, boolean isBookmarked) {
+    @Transactional
+    public void updateBookmarkStatus(User user, BookmarkRequestDTO.Bookmark bookmarkRequestDTO) {
+        Long tipId = bookmarkRequestDTO.getTipId();
+        boolean isBookmarked = bookmarkRequestDTO.getIsBookmarked();
+
         Tip tip = tipRepository.findById(tipId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 팁이 존재하지 않습니다."));
 
@@ -30,7 +34,5 @@ public class BookmarkServiceImpl implements BookmarkService {
         } else if (!isBookmarked && exists) {
             bookmarkRepository.deleteByUserAndTip(user, tip);
         }
-
-        return new BookmarkResponseDTO.BookmarkResult(tipId, isBookmarked);
     }
 }

--- a/src/main/java/com/k_passs/backend/domain/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/k_passs/backend/domain/bookmark/service/BookmarkServiceImpl.java
@@ -1,0 +1,36 @@
+package com.k_passs.backend.domain.bookmark.service;
+
+import com.k_passs.backend.domain.bookmark.dto.BookmarkResponseDTO;
+import com.k_passs.backend.domain.bookmark.entity.Bookmark;
+import com.k_passs.backend.domain.bookmark.repository.BookmarkRepository;
+import com.k_passs.backend.domain.tip.entity.Tip;
+import com.k_passs.backend.domain.tip.repository.TipRepository;
+import com.k_passs.backend.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkServiceImpl implements BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final TipRepository tipRepository;
+
+    @Override
+    public BookmarkResponseDTO.BookmarkResult updateBookmarkStatus(User user, Long tipId, boolean isBookmarked) {
+        Tip tip = tipRepository.findById(tipId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 팁이 존재하지 않습니다."));
+
+        boolean exists = bookmarkRepository.existsByUserAndTip(user, tip);
+
+        if (isBookmarked && !exists) {
+            bookmarkRepository.save(new Bookmark(user, tip));
+        } else if (!isBookmarked && exists) {
+            bookmarkRepository.deleteByUserAndTip(user, tip);
+        }
+
+        return new BookmarkResponseDTO.BookmarkResult(tipId, isBookmarked);
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/tip/api/TipRestController.java
+++ b/src/main/java/com/k_passs/backend/domain/tip/api/TipRestController.java
@@ -1,0 +1,53 @@
+package com.k_passs.backend.domain.tip.api;
+
+import com.k_passs.backend.domain.tip.dto.TipResponseDTO;
+import com.k_passs.backend.domain.tip.service.TipService;
+import com.k_passs.backend.global.common.response.BaseResponse;
+import com.k_passs.backend.global.error.code.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/tip")
+public class TipRestController {
+    private final TipService tipService;
+
+
+
+    @GetMapping("/{tipId}")
+    @Operation(summary = "특정 꿀팁의 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "TIP_200", description = "특정 꿀팁의 정보를 성공적으로 조회했습니다.")
+    })
+    @Parameters({
+            @Parameter(name = "tipId", description = "꿀팁의 id, path variable 입니다.")
+    })
+    public BaseResponse<TipResponseDTO.GetTipResult> getTip(
+            @PathVariable Long tipId
+    ) {
+        TipResponseDTO.GetTipResult result = tipService.getTip(tipId);
+        return BaseResponse.onSuccess(SuccessStatus.TIP_SUCCESS, result);
+    }
+
+    @GetMapping
+    @Operation(summary = "전체 꿀팁 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "TIP_200", description = "전체 꿀팁 정보를 성공적으로 조회했습니다.")
+    })
+    public BaseResponse<List<TipResponseDTO.GetAllTipResult>> getAllTips() {
+        List<TipResponseDTO.GetAllTipResult> result = tipService.getAllTips();
+        return BaseResponse.onSuccess(SuccessStatus.TIP_SUCCESS, result);
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/tip/api/TipRestController.java
+++ b/src/main/java/com/k_passs/backend/domain/tip/api/TipRestController.java
@@ -24,8 +24,6 @@ import java.util.List;
 public class TipRestController {
     private final TipService tipService;
 
-
-
     @GetMapping("/{tipId}")
     @Operation(summary = "특정 꿀팁의 상세 정보를 조회합니다.")
     @ApiResponses({

--- a/src/main/java/com/k_passs/backend/domain/tip/api/TipRestController.java
+++ b/src/main/java/com/k_passs/backend/domain/tip/api/TipRestController.java
@@ -46,6 +46,6 @@ public class TipRestController {
     })
     public BaseResponse<List<TipResponseDTO.GetAllTipResult>> getAllTips() {
         List<TipResponseDTO.GetAllTipResult> result = tipService.getAllTips();
-        return BaseResponse.onSuccess(SuccessStatus.TIP_SUCCESS, result);
+        return BaseResponse.onSuccess(SuccessStatus.TIP_ALL_SUCCESS, result);
     }
 }

--- a/src/main/java/com/k_passs/backend/domain/tip/converter/TipConverter.java
+++ b/src/main/java/com/k_passs/backend/domain/tip/converter/TipConverter.java
@@ -10,6 +10,9 @@ public class TipConverter {
                 .id(tip.getId())
                 .title(tip.getTitle())
                 .content(tip.getContent())
+                .imageUrl(tip.getImageUrl())
+                .hashtags(tip.getHashtags())
+                .infoText(tip.getInfoText())
                 .createdAt(tip.getCreatedAt())
                 .build();
     }
@@ -18,6 +21,8 @@ public class TipConverter {
         return TipResponseDTO.GetAllTipResult.builder()
                 .id(tip.getId())
                 .title(tip.getTitle())
+                .imageUrl(tip.getImageUrl())
+                .hashtags(tip.getHashtags())
                 .build();
     }
 }

--- a/src/main/java/com/k_passs/backend/domain/tip/converter/TipConverter.java
+++ b/src/main/java/com/k_passs/backend/domain/tip/converter/TipConverter.java
@@ -12,7 +12,6 @@ public class TipConverter {
                 .content(tip.getContent())
                 .imageUrl(tip.getImageUrl())
                 .hashtags(tip.getHashtags())
-                .infoText(tip.getInfoText())
                 .createdAt(tip.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/k_passs/backend/domain/tip/converter/TipConverter.java
+++ b/src/main/java/com/k_passs/backend/domain/tip/converter/TipConverter.java
@@ -3,6 +3,9 @@ package com.k_passs.backend.domain.tip.converter;
 import com.k_passs.backend.domain.tip.entity.Tip;
 import com.k_passs.backend.domain.tip.dto.TipResponseDTO;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class TipConverter {
 
     public static TipResponseDTO.GetTipResult toGetTip(Tip tip) {
@@ -11,7 +14,7 @@ public class TipConverter {
                 .title(tip.getTitle())
                 .content(tip.getContent())
                 .imageUrl(tip.getImageUrl())
-                .hashtags(tip.getHashtags())
+                .hashtags(tip.getHashtags() != null ? Arrays.asList(tip.getHashtags().split(",")) : List.of())
                 .createdAt(tip.getCreatedAt())
                 .build();
     }
@@ -21,7 +24,7 @@ public class TipConverter {
                 .id(tip.getId())
                 .title(tip.getTitle())
                 .imageUrl(tip.getImageUrl())
-                .hashtags(tip.getHashtags())
+                .hashtags(tip.getHashtags() != null ? Arrays.asList(tip.getHashtags().split(",")) : List.of())
                 .build();
     }
 }

--- a/src/main/java/com/k_passs/backend/domain/tip/converter/TipConverter.java
+++ b/src/main/java/com/k_passs/backend/domain/tip/converter/TipConverter.java
@@ -1,0 +1,23 @@
+package com.k_passs.backend.domain.tip.converter;
+
+import com.k_passs.backend.domain.tip.entity.Tip;
+import com.k_passs.backend.domain.tip.dto.TipResponseDTO;
+
+public class TipConverter {
+
+    public static TipResponseDTO.GetTipResult toGetTip(Tip tip) {
+        return TipResponseDTO.GetTipResult.builder()
+                .id(tip.getId())
+                .title(tip.getTitle())
+                .content(tip.getContent())
+                .createdAt(tip.getCreatedAt())
+                .build();
+    }
+
+    public static TipResponseDTO.GetAllTipResult toGetAllTip(Tip tip) {
+        return TipResponseDTO.GetAllTipResult.builder()
+                .id(tip.getId())
+                .title(tip.getTitle())
+                .build();
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/tip/dto/TipRequestDTO.java
+++ b/src/main/java/com/k_passs/backend/domain/tip/dto/TipRequestDTO.java
@@ -1,0 +1,5 @@
+package com.k_passs.backend.domain.tip.dto;
+
+public class TipRequestDTO {
+
+}

--- a/src/main/java/com/k_passs/backend/domain/tip/dto/TipResponseDTO.java
+++ b/src/main/java/com/k_passs/backend/domain/tip/dto/TipResponseDTO.java
@@ -1,0 +1,33 @@
+package com.k_passs.backend.domain.tip.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class TipResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetTipResult {
+        private Long id;
+        private String title;
+        private String content;
+        private LocalDateTime createdAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetAllTipResult {
+        private Long id;
+        private String title;
+    }
+
+
+}

--- a/src/main/java/com/k_passs/backend/domain/tip/dto/TipResponseDTO.java
+++ b/src/main/java/com/k_passs/backend/domain/tip/dto/TipResponseDTO.java
@@ -17,6 +17,9 @@ public class TipResponseDTO {
         private Long id;
         private String title;
         private String content;
+        private String imageUrl;
+        private String hashtags;
+        private String infoText;
         private LocalDateTime createdAt;
     }
 
@@ -27,7 +30,7 @@ public class TipResponseDTO {
     public static class GetAllTipResult {
         private Long id;
         private String title;
+        private String imageUrl;
+        private String hashtags;
     }
-
-
 }

--- a/src/main/java/com/k_passs/backend/domain/tip/dto/TipResponseDTO.java
+++ b/src/main/java/com/k_passs/backend/domain/tip/dto/TipResponseDTO.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class TipResponseDTO {
 
@@ -18,7 +19,7 @@ public class TipResponseDTO {
         private String title;
         private String content;
         private String imageUrl;
-        private String hashtags;
+        private List<String> hashtags;
         private LocalDateTime createdAt;
     }
 
@@ -30,6 +31,6 @@ public class TipResponseDTO {
         private Long id;
         private String title;
         private String imageUrl;
-        private String hashtags;
+        private List<String> hashtags;
     }
 }

--- a/src/main/java/com/k_passs/backend/domain/tip/dto/TipResponseDTO.java
+++ b/src/main/java/com/k_passs/backend/domain/tip/dto/TipResponseDTO.java
@@ -19,7 +19,6 @@ public class TipResponseDTO {
         private String content;
         private String imageUrl;
         private String hashtags;
-        private String infoText;
         private LocalDateTime createdAt;
     }
 

--- a/src/main/java/com/k_passs/backend/domain/tip/entity/Tip.java
+++ b/src/main/java/com/k_passs/backend/domain/tip/entity/Tip.java
@@ -22,8 +22,23 @@ public class Tip extends BaseEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    public Tip(String title, String content) {
+    // 사진 URL
+    @Column(length = 255)
+    private String imageUrl;
+
+    // 해시태그
+    @Column(length = 255)
+    private String hashtags;
+
+    // 추가 정보 텍스트
+    @Column(length = 255)
+    private String infoText;
+
+    public Tip(String title, String content, String imageUrl, String hashtags, String infoText) {
         this.title = title;
         this.content = content;
+        this.imageUrl = imageUrl;
+        this.hashtags = hashtags;
+        this.infoText = infoText;
     }
 }

--- a/src/main/java/com/k_passs/backend/domain/tip/entity/Tip.java
+++ b/src/main/java/com/k_passs/backend/domain/tip/entity/Tip.java
@@ -30,15 +30,10 @@ public class Tip extends BaseEntity {
     @Column(length = 255)
     private String hashtags;
 
-    // 추가 정보 텍스트
-    @Column(length = 255)
-    private String infoText;
-
     public Tip(String title, String content, String imageUrl, String hashtags, String infoText) {
         this.title = title;
         this.content = content;
         this.imageUrl = imageUrl;
         this.hashtags = hashtags;
-        this.infoText = infoText;
     }
 }

--- a/src/main/java/com/k_passs/backend/domain/tip/entity/Tip.java
+++ b/src/main/java/com/k_passs/backend/domain/tip/entity/Tip.java
@@ -1,4 +1,4 @@
-package com.k_passs.backend.domain.tip;
+package com.k_passs.backend.domain.tip.entity;
 
 import com.k_passs.backend.domain.model.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -21,4 +21,9 @@ public class Tip extends BaseEntity {
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
+
+    public Tip(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/k_passs/backend/domain/tip/repository/TipRepository.java
+++ b/src/main/java/com/k_passs/backend/domain/tip/repository/TipRepository.java
@@ -1,0 +1,7 @@
+package com.k_passs.backend.domain.tip.repository;
+
+import com.k_passs.backend.domain.tip.entity.Tip;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TipRepository extends JpaRepository<Tip, Long> {
+}

--- a/src/main/java/com/k_passs/backend/domain/tip/service/TipService.java
+++ b/src/main/java/com/k_passs/backend/domain/tip/service/TipService.java
@@ -1,0 +1,11 @@
+package com.k_passs.backend.domain.tip.service;
+
+import com.k_passs.backend.domain.tip.dto.TipResponseDTO;
+import com.k_passs.backend.domain.tip.entity.Tip;
+
+import java.util.List;
+
+public interface TipService {
+    TipResponseDTO.GetTipResult getTip(Long tipId);
+    List<TipResponseDTO.GetAllTipResult> getAllTips();
+}

--- a/src/main/java/com/k_passs/backend/domain/tip/service/TipServiceImpl.java
+++ b/src/main/java/com/k_passs/backend/domain/tip/service/TipServiceImpl.java
@@ -1,0 +1,35 @@
+package com.k_passs.backend.domain.tip.service;
+
+import com.k_passs.backend.domain.tip.converter.TipConverter;
+import com.k_passs.backend.domain.tip.dto.TipResponseDTO;
+import com.k_passs.backend.domain.tip.entity.Tip;
+import com.k_passs.backend.domain.tip.repository.TipRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TipServiceImpl implements TipService {
+
+    private final TipRepository tipRepository;
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public TipResponseDTO.GetTipResult getTip(Long tipId) {
+        Tip tip = tipRepository.findById(tipId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 팁이 존재하지 않습니다."));
+        return TipConverter.toGetTip(tip);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<TipResponseDTO.GetAllTipResult> getAllTips() {
+        return tipRepository.findAll().stream()
+                .map(TipConverter::toGetAllTip)
+                .toList();
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/user/controller/KakaoAuthController.java
+++ b/src/main/java/com/k_passs/backend/domain/user/controller/KakaoAuthController.java
@@ -11,7 +11,7 @@ import org.springframework.http.HttpStatus;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/auth")
 public class KakaoAuthController {
 
     // 클라이언트에서 카카오 액세스 토큰을 전달받아 로그인 처리

--- a/src/main/java/com/k_passs/backend/domain/user/controller/KakaoAuthController.java
+++ b/src/main/java/com/k_passs/backend/domain/user/controller/KakaoAuthController.java
@@ -3,6 +3,7 @@ package com.k_passs.backend.domain.user.controller;
 
 import com.k_passs.backend.domain.user.util.JwtUtil;
 import com.k_passs.backend.global.error.code.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestTemplate;
@@ -10,6 +11,7 @@ import org.springframework.http.HttpStatus;
 
 import java.util.Map;
 
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/auth")
 public class KakaoAuthController {

--- a/src/main/java/com/k_passs/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/k_passs/backend/domain/user/controller/UserController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.http.ResponseEntity;
 
 @RestController
-@RequestMapping("/api/user")
+@RequestMapping("/user")
 @RequiredArgsConstructor
 public class UserController {
 

--- a/src/main/java/com/k_passs/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/k_passs/backend/domain/user/service/UserService.java
@@ -1,0 +1,29 @@
+package com.k_passs.backend.domain.user.service;
+
+import com.k_passs.backend.domain.user.entity.User;
+import com.k_passs.backend.domain.user.repogitory.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public User getUserById(Long id) {
+        Optional<User> user = userRepository.findById(id);
+
+        if (user.isPresent()) {
+            System.out.println("[DEBUG] 사용자 조회 성공: " + user.get());
+        } else {
+            System.out.println("[DEBUG] 사용자 조회 실패: ID = " + id);
+        }
+
+        return user.orElseThrow(() -> new IllegalArgumentException("테스트용 사용자 ID를 찾을 수 없습니다: " + id));
+    }
+}

--- a/src/main/java/com/k_passs/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/k_passs/backend/global/config/SecurityConfig.java
@@ -36,8 +36,19 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .cors(cors -> {})
+//                .authorizeHttpRequests(auth -> auth
+//                        .requestMatchers("/api/auth/**").permitAll()
+//                        .anyRequest().authenticated()
+//                )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers(
+                                "/api/auth/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                                "/webjars/**"
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session ->

--- a/src/main/java/com/k_passs/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/k_passs/backend/global/config/SecurityConfig.java
@@ -36,10 +36,6 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .cors(cors -> {})
-//                .authorizeHttpRequests(auth -> auth
-//                        .requestMatchers("/api/auth/**").permitAll()
-//                        .anyRequest().authenticated()
-//                )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/auth/**",
@@ -47,7 +43,12 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",
-                                "/webjars/**"
+                                "/webjars/**",
+                                "/auth/kakao",
+                                "/kakao/**",
+                                "/callback/**",
+                                "/bookmark/**",
+                                "tip/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/k_passs/backend/global/error/code/status/SuccessStatus.java
+++ b/src/main/java/com/k_passs/backend/global/error/code/status/SuccessStatus.java
@@ -12,7 +12,16 @@ import org.springframework.http.HttpStatus;
 public enum SuccessStatus implements BaseCode {
 
     //Common
-    OK(HttpStatus.OK, "COMMON_200", "성공입니다.");
+    OK(HttpStatus.OK, "COMMON_200", "성공입니다."),
+
+    // Bookmark
+    BOOKMARK_STATUS_CHANGED(HttpStatus.OK, "BOOKMARK_200","북마크 상태가 성공적으로 변경되었습니다."),
+
+    // Tip
+    TIP_SUCCESS(HttpStatus.OK,"TIP_200", "꿀팁이 성공적으로 조회되었습니다."),
+    ;
+
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/k_passs/backend/global/error/code/status/SuccessStatus.java
+++ b/src/main/java/com/k_passs/backend/global/error/code/status/SuccessStatus.java
@@ -19,6 +19,7 @@ public enum SuccessStatus implements BaseCode {
 
     // Tip
     TIP_SUCCESS(HttpStatus.OK,"TIP_200", "꿀팁이 성공적으로 조회되었습니다."),
+    TIP_ALL_SUCCESS(HttpStatus.OK,"TIP_200", "전체 꿀팁이 성공적으로 조회되었습니다."),
     ;
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,7 +25,7 @@ spring:
             scope: profile_nickname, profile_image, account_email
             client-name: Kakao
             authorization-grant-type: authorization_code
-            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            redirect-uri: http://localhost:8080/callback
             client-authentication-method: client_secret_post
         provider:
           kakao:


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #7 

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 북마크의 경우, 북마크 상태 전환 기능을 구현했습니다.
- 팁의 경우, Entity에 이미지url, 팁 정보 text, 해시태그 Text를 추가했습니다.
- 전체 팁 조회의 경우, List로 지정했습니다.
- 해시태그는 List 로 지정했습니다.

<img width="500"  src="https://github.com/user-attachments/assets/26ea9701-e273-4390-8328-a06316e6f480" />

<img width="500" src="https://github.com/user-attachments/assets/deee0b8e-b745-497f-9749-63010cef61e6" />

<img width="500" src="https://github.com/user-attachments/assets/14bdb1d2-576f-4690-9be9-a2cf7ffbac29" />

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- 아직 소셜 로그인 구현이 미완성이다 보니, 전체 권한 지정으로 설정해서 스웨거 테스트를 진행했었습니다
