### PR TITLE
[#4] 고지서 ocr 기능 구현

### DIFF
--- a/src/main/java/com/k_passs/backend/domain/bill/Bill.java
+++ b/src/main/java/com/k_passs/backend/domain/bill/Bill.java
@@ -1,7 +1,7 @@
 package com.k_passs.backend.domain.bill;
 
 import com.k_passs.backend.domain.model.entity.BaseEntity;
-import com.k_passs.backend.domain.model.enums.BillCategory;
+import com.k_passs.backend.domain.model.enums.BillType;
 import com.k_passs.backend.domain.model.enums.BillStatus;
 import com.k_passs.backend.domain.user.User;
 import jakarta.persistence.*;
@@ -31,7 +31,7 @@ public class Bill extends BaseEntity {
 
     @Enumerated(EnumType.STRING) // Enum 타입을 DB에 문자열로 저장
     @Column(nullable = false)
-    private BillCategory category;
+    private BillType category;
 
     // 금액은 부동소수점 오류를 피하기 위해 BigDecimal 사용
     @Column(nullable = false, precision = 12, scale = 2)

--- a/src/main/java/com/k_passs/backend/domain/bill/controller/BillController.java
+++ b/src/main/java/com/k_passs/backend/domain/bill/controller/BillController.java
@@ -1,0 +1,28 @@
+package com.k_passs.backend.domain.bill.controller;
+
+import com.k_passs.backend.domain.bill.dto.BillOcrResponseDto;
+import com.k_passs.backend.domain.bill.service.BillOcrService;
+import com.k_passs.backend.domain.model.enums.BillType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class BillController {
+
+    private final BillOcrService billOcrService;
+
+    @PostMapping(value = "/user/{userId}/bill/ocr", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<BillOcrResponseDto> analyzeBill(
+            @PathVariable Long userId,
+            @RequestParam("billType") BillType billType,
+            @RequestParam("billImage") MultipartFile billImage) {
+
+        BillOcrResponseDto result = billOcrService.analyzeBill(userId, billType, billImage);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/bill/dto/BillOcrResponseDto.java
+++ b/src/main/java/com/k_passs/backend/domain/bill/dto/BillOcrResponseDto.java
@@ -11,4 +11,5 @@ public class BillOcrResponseDto {
     private BillType billType;
     private Integer amount;
     private String usagePeriod;
+    private String rawText;
 }

--- a/src/main/java/com/k_passs/backend/domain/bill/dto/BillOcrResponseDto.java
+++ b/src/main/java/com/k_passs/backend/domain/bill/dto/BillOcrResponseDto.java
@@ -1,0 +1,14 @@
+package com.k_passs.backend.domain.bill.dto;
+
+import com.k_passs.backend.domain.model.enums.BillType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BillOcrResponseDto {
+    //임시
+    private BillType billType;
+    private Integer amount;
+    private String usagePeriod;
+}

--- a/src/main/java/com/k_passs/backend/domain/bill/entity/Bill.java
+++ b/src/main/java/com/k_passs/backend/domain/bill/entity/Bill.java
@@ -5,9 +5,7 @@ import com.k_passs.backend.domain.model.enums.BillType;
 import com.k_passs.backend.domain.model.enums.BillStatus;
 import com.k_passs.backend.domain.user.entity.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -15,6 +13,8 @@ import java.time.LocalDate;
 @Entity
 @Table(name = "bills")
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Bill extends BaseEntity {
 

--- a/src/main/java/com/k_passs/backend/domain/bill/entity/Bill.java
+++ b/src/main/java/com/k_passs/backend/domain/bill/entity/Bill.java
@@ -1,9 +1,9 @@
-package com.k_passs.backend.domain.bill;
+package com.k_passs.backend.domain.bill.entity;
 
 import com.k_passs.backend.domain.model.entity.BaseEntity;
 import com.k_passs.backend.domain.model.enums.BillType;
 import com.k_passs.backend.domain.model.enums.BillStatus;
-import com.k_passs.backend.domain.user.User;
+import com.k_passs.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/k_passs/backend/domain/bill/repository/BillRepository.java
+++ b/src/main/java/com/k_passs/backend/domain/bill/repository/BillRepository.java
@@ -1,0 +1,7 @@
+package com.k_passs.backend.domain.bill.repository;
+
+import com.k_passs.backend.domain.bill.entity.Bill;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BillRepository extends JpaRepository<Bill, Long> {
+}

--- a/src/main/java/com/k_passs/backend/domain/bill/service/BillOcrService.java
+++ b/src/main/java/com/k_passs/backend/domain/bill/service/BillOcrService.java
@@ -1,0 +1,55 @@
+package com.k_passs.backend.domain.bill.service;
+
+import com.k_passs.backend.domain.bill.dto.BillOcrResponseDto;
+import com.k_passs.backend.domain.bill.entity.Bill;
+import com.k_passs.backend.domain.bill.repository.BillRepository;
+import com.k_passs.backend.domain.model.enums.BillStatus;
+import com.k_passs.backend.domain.model.enums.BillType;
+import com.k_passs.backend.domain.user.entity.User;
+import com.k_passs.backend.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class BillOcrService {
+
+    private final BillRepository billRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public BillOcrResponseDto analyzeBill(Long userId, BillType billType, MultipartFile billImage) {
+        // 1. DB에 저장된 테스트용 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. ID: " + userId));
+
+        // 2. [임시] OCR 분석 로직 (지금은 가짜 데이터 사용)
+        System.out.println("전달받은 파일: " + billImage.getOriginalFilename());
+        System.out.println("고지서 종류: " + billType);
+
+        Integer fakeAmount = 12345; // 가짜 금액
+        String fakePeriod = "2025-08"; // 가짜 사용기간
+
+        // 3. 분석된 정보로 Bill 엔티티를 만들어 DB에 저장
+        Bill newBill = Bill.builder()
+                .user(user)
+                .category(billType)
+                .totalAmount(BigDecimal.valueOf(fakeAmount))
+                .periodMonth(LocalDate.now()) // 임시로 현재 날짜 저장
+                .status(BillStatus.UNPAID) // 임시로 '미납' 상태로 저장
+                .build();
+        billRepository.save(newBill);
+
+        // 4. Controller에 반환할 응답 DTO 생성
+        return BillOcrResponseDto.builder()
+                .billType(billType)
+                .amount(fakeAmount)
+                .usagePeriod(fakePeriod)
+                .build();
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/bill/service/BillOcrService.java
+++ b/src/main/java/com/k_passs/backend/domain/bill/service/BillOcrService.java
@@ -5,6 +5,8 @@ import com.k_passs.backend.domain.bill.entity.Bill;
 import com.k_passs.backend.domain.bill.repository.BillRepository;
 import com.k_passs.backend.domain.model.enums.BillStatus;
 import com.k_passs.backend.domain.model.enums.BillType;
+import com.k_passs.backend.domain.ocr.client.OcrApiClient; // 1. OcrApiClient 임포트
+import com.k_passs.backend.domain.ocr.dto.NaverOcrResponseDto; // 1. NaverOcrResponseDto 임포트
 import com.k_passs.backend.domain.user.entity.User;
 import com.k_passs.backend.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -14,6 +16,10 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
@@ -21,35 +27,92 @@ public class BillOcrService {
 
     private final BillRepository billRepository;
     private final UserRepository userRepository;
+    private final OcrApiClient ocrApiClient; // 2. OcrApiClient 의존성 주입
 
     @Transactional
     public BillOcrResponseDto analyzeBill(Long userId, BillType billType, MultipartFile billImage) {
-        // 1. DB에 저장된 테스트용 사용자 조회
+        // 1. DB에 저장된 사용자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. ID: " + userId));
 
-        // 2. [임시] OCR 분석 로직 (지금은 가짜 데이터 사용)
-        System.out.println("전달받은 파일: " + billImage.getOriginalFilename());
-        System.out.println("고지서 종류: " + billType);
+        // 2. OcrApiClient를 통해 실제 네이버 OCR API 호출
+        NaverOcrResponseDto ocrResult = ocrApiClient.requestOcr(billImage);
 
-        Integer fakeAmount = 12345; // 가짜 금액
-        String fakePeriod = "2025-08"; // 가짜 사용기간
+        // 3. OCR 결과에서 모든 텍스트를 하나로 합치기
+        String rawText = extractTextFromOcrResult(ocrResult);
+        System.out.println("### OCR 분석 전체 텍스트: " + rawText); // 콘솔에서 결과 확인
 
-        // 3. 분석된 정보로 Bill 엔티티를 만들어 DB에 저장
+        // 4. 텍스트에서 금액과 사용기간 파싱
+        Integer amount = parseAmountFromText(rawText, billType);
+        String usagePeriod = parsePeriodFromText(rawText, billType); // "YYYY-MM" 형식
+
+        // 5. 파싱된 정보로 Bill 엔티티를 만들어 DB에 저장
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
+        YearMonth ym = YearMonth.parse(usagePeriod, formatter);
+        LocalDate periodDate = ym.atDay(1);
+
         Bill newBill = Bill.builder()
                 .user(user)
                 .category(billType)
-                .totalAmount(BigDecimal.valueOf(fakeAmount))
-                .periodMonth(LocalDate.now()) // 임시로 현재 날짜 저장
-                .status(BillStatus.UNPAID) // 임시로 '미납' 상태로 저장
+                .totalAmount(BigDecimal.valueOf(amount))
+                .periodMonth(periodDate) // 파싱된 날짜로 저장
+                .status(BillStatus.UNPAID)
                 .build();
         billRepository.save(newBill);
 
-        // 4. Controller에 반환할 응답 DTO 생성
+        // 6. Controller에 반환할 응답 DTO 생성
         return BillOcrResponseDto.builder()
                 .billType(billType)
-                .amount(fakeAmount)
-                .usagePeriod(fakePeriod)
+                .amount(amount)
+                .usagePeriod(usagePeriod)
+                .rawText(rawText)
                 .build();
+    }
+
+    /**
+     * NaverOcrResponseDto에서 모든 텍스트를 추출하여 하나의 문자열로 합칩니다.
+     */
+    private String extractTextFromOcrResult(NaverOcrResponseDto ocrResult) {
+        if (ocrResult == null || ocrResult.getImages() == null) {
+            return "";
+        }
+        StringBuilder textBuilder = new StringBuilder();
+        ocrResult.getImages().forEach(image ->
+                image.getFields().forEach(field ->
+                        textBuilder.append(field.getInferText()).append(" ")
+                )
+        );
+        return textBuilder.toString();
+    }
+
+    /**
+     * OCR 텍스트에서 금액을 추출합니다.
+     */
+    private Integer parseAmountFromText(String rawText, BillType billType) {
+        // TODO: billType에 따라 다른 정규 표현식을 사용하여 금액을 파싱하는 로직 구현 필요
+        // 예시: "청구금액 12,345원", "합계 54,321" 등의 패턴 찾기
+        Pattern pattern = Pattern.compile("청구금액\\s*([\\d,]+)원?"); // "청구금액" 뒤 숫자 추출 예시
+        Matcher matcher = pattern.matcher(rawText);
+        if (matcher.find()) {
+            String amountStr = matcher.group(1).replaceAll(",", ""); // 쉼표 제거
+            return Integer.parseInt(amountStr);
+        }
+        return 0; // 금액을 찾지 못했을 경우 기본값
+    }
+
+    /**
+     * OCR 텍스트에서 사용 기간(YYYY-MM)을 추출합니다.
+     */
+    private String parsePeriodFromText(String rawText, BillType billType) {
+        // TODO: billType에 따라 다른 정규 표현식을 사용하여 기간을 파싱하는 로직 구현 필요
+        // 예시: "2025년 08월분", "사용기간: 2025. 08. 01 ~ 2025. 08. 31" 등의 패턴 찾기
+        Pattern pattern = Pattern.compile("(\\d{4})년\\s*(\\d{1,2})월"); // "YYYY년 MM월" 패턴 추출 예시
+        Matcher matcher = pattern.matcher(rawText);
+        if (matcher.find()) {
+            String year = matcher.group(1);
+            String month = String.format("%02d", Integer.parseInt(matcher.group(2))); // 월을 두 자리로 포맷팅
+            return year + "-" + month;
+        }
+        return "2025-01"; // 기간을 찾지 못했을 경우 기본값
     }
 }

--- a/src/main/java/com/k_passs/backend/domain/challenge/entity/Challenge.java
+++ b/src/main/java/com/k_passs/backend/domain/challenge/entity/Challenge.java
@@ -1,4 +1,4 @@
-package com.k_passs.backend.domain.challenge;
+package com.k_passs.backend.domain.challenge.entity;
 
 import com.k_passs.backend.domain.model.entity.BaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/k_passs/backend/domain/model/enums/BillType.java
+++ b/src/main/java/com/k_passs/backend/domain/model/enums/BillType.java
@@ -1,6 +1,6 @@
 package com.k_passs.backend.domain.model.enums;
 
-public enum BillCategory {
+public enum BillType {
     ELECTRICITY,
     WATER,
     GAS

--- a/src/main/java/com/k_passs/backend/domain/ocr/client/OcrApiClient.java
+++ b/src/main/java/com/k_passs/backend/domain/ocr/client/OcrApiClient.java
@@ -1,0 +1,82 @@
+package com.k_passs.backend.domain.ocr.client;
+
+import com.k_passs.backend.domain.ocr.dto.NaverOcrResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class OcrApiClient {
+
+    @Value("${ncp.api.url}")
+    private String apiUrl;
+
+    @Value("${ncp.api.secret-key}")
+    private String secretKey;
+
+    private final RestTemplate restTemplate;
+
+    public NaverOcrResponseDto requestOcr(MultipartFile imageFile) {
+        try {
+            // 1. 요청 헤더 설정: 인증 키 포함
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.set("X-OCR-SECRET", secretKey);
+
+            // 2. 요청 바디 설정: 네이버 OCR API 명세에 따름
+            String base64Image = encodeImageToBase64(imageFile);
+            String format = getFileExtension(imageFile);
+
+            Map<String, Object> image = new HashMap<>();
+            image.put("format", format);
+            image.put("name", "bill-image");
+            image.put("data", base64Image);
+
+            Map<String, Object> body = new HashMap<>();
+            body.put("version", "V2");
+            body.put("requestId", UUID.randomUUID().toString());
+            body.put("timestamp", System.currentTimeMillis());
+            body.put("images", Collections.singletonList(image));
+
+            // 3. HTTP 요청 엔티티 생성
+            HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+
+            // 4. RestTemplate을 사용하여 API 호출 및 응답 받기
+            NaverOcrResponseDto response = restTemplate.postForObject(apiUrl, requestEntity, NaverOcrResponseDto.class);
+
+            return response;
+
+        } catch (IOException e) {
+            throw new RuntimeException("이미지 파일을 처리하는 중 오류가 발생했습니다.", e);
+        } catch (Exception e) {
+            throw new RuntimeException("OCR API를 호출하는 중 오류가 '발생했습니다.", e);
+        }
+    }
+
+    // 이미지를 Base64로 인코딩하는 헬퍼 메소드
+    private String encodeImageToBase64(MultipartFile imageFile) throws IOException {
+        return Base64.getEncoder().encodeToString(imageFile.getBytes());
+    }
+
+    // 파일 확장자를 추출하는 헬퍼 메소드
+    private String getFileExtension(MultipartFile imageFile) {
+        String originalFilename = imageFile.getOriginalFilename();
+        if (originalFilename == null || originalFilename.lastIndexOf('.') == -1) {
+            return "jpg";
+        }
+        return originalFilename.substring(originalFilename.lastIndexOf('.') + 1);
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/ocr/dto/NaverOcrResponseDto.java
+++ b/src/main/java/com/k_passs/backend/domain/ocr/dto/NaverOcrResponseDto.java
@@ -1,0 +1,60 @@
+package com.k_passs.backend.domain.ocr.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+public class NaverOcrResponseDto {
+
+    private String version;
+    private String requestId;
+    private long timestamp;
+    private List<Image> images;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @ToString
+    public static class Image {
+        private String uid;
+        private String name;
+        private String inferResult;
+        private String message;
+        private List<Field> fields;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @ToString
+    public static class Field {
+        private String valueType;
+        private BoundingPoly boundingPoly;
+        private String inferText;
+        private double inferConfidence;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @ToString
+    public static class BoundingPoly {
+        private List<Vertex> vertices;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @ToString
+    public static class Vertex {
+        private double x;
+        private double y;
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/tip/entity/Tip.java
+++ b/src/main/java/com/k_passs/backend/domain/tip/entity/Tip.java
@@ -1,4 +1,4 @@
-package com.k_passs.backend.domain.tip;
+package com.k_passs.backend.domain.tip.entity;
 
 import com.k_passs.backend.domain.model.entity.BaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/k_passs/backend/domain/user/entity/Bookmark.java
+++ b/src/main/java/com/k_passs/backend/domain/user/entity/Bookmark.java
@@ -1,7 +1,7 @@
-package com.k_passs.backend.domain.user;
+package com.k_passs.backend.domain.user.entity;
 
 import com.k_passs.backend.domain.model.entity.BaseEntity;
-import com.k_passs.backend.domain.tip.Tip;
+import com.k_passs.backend.domain.tip.entity.Tip;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/k_passs/backend/domain/user/entity/PointHistory.java
+++ b/src/main/java/com/k_passs/backend/domain/user/entity/PointHistory.java
@@ -1,4 +1,4 @@
-package com.k_passs.backend.domain.user;
+package com.k_passs.backend.domain.user.entity;
 
 import com.k_passs.backend.domain.model.entity.BaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/k_passs/backend/domain/user/entity/User.java
+++ b/src/main/java/com/k_passs/backend/domain/user/entity/User.java
@@ -1,6 +1,6 @@
-package com.k_passs.backend.domain.user;
+package com.k_passs.backend.domain.user.entity;
 
-import com.k_passs.backend.domain.bill.Bill;
+import com.k_passs.backend.domain.bill.entity.Bill;
 import com.k_passs.backend.domain.model.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/k_passs/backend/domain/user/entity/UserChallenge.java
+++ b/src/main/java/com/k_passs/backend/domain/user/entity/UserChallenge.java
@@ -1,6 +1,6 @@
-package com.k_passs.backend.domain.user;
+package com.k_passs.backend.domain.user.entity;
 
-import com.k_passs.backend.domain.challenge.Challenge;
+import com.k_passs.backend.domain.challenge.entity.Challenge;
 import com.k_passs.backend.domain.model.entity.BaseEntity;
 import com.k_passs.backend.domain.model.enums.ChallengeStatus;
 import jakarta.persistence.*;

--- a/src/main/java/com/k_passs/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/k_passs/backend/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.k_passs.backend.domain.user.repository;
+
+import com.k_passs.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/k_passs/backend/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/k_passs/backend/global/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.k_passs.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,3 +26,9 @@ logging:
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
     org.springframework.jdbc.core: DEBUG
+
+# Naver Cloud Platform OCR API Credentials
+ncp:
+  api:
+    url: ${NCP_APIGW_URL}
+    secret-key: ${NCP_SECRET_KEY}


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #4 

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
POST /api/user/{userId}/bill/ocr 구현 하였습니다

고지서이미지를 입력받은 후, 네이버클로버의 ocr을 사용하여 모든 텍스트를 추출하는 api입니다
추후 회의 이후에 amount, usagePeriod등 필요한 정보만 파싱하는 로직을 BillOcrService에 추가구현해야합니다
(현재는 rawText라는 필드를 임시로 추가하여 테스트하는 구조 입니다

-NCP OCR 연동
OcrApiClient (네이버 API 통신 클라이언트) 구현
RestTemplateConfig 추가
NaverOcrResponseDto (API 응답 매핑 DTO) 추가

-Service 로직: BillOcrService에 API 호출 및 rawText 추출 로직 통합

-Config: application.yml에 NCP 연동을 위한 url, secret-key 추가 (.env에 보관)

<img width="1504" height="771" alt="image" src="https://github.com/user-attachments/assets/f9341e9c-1aa6-474d-af2a-0047b2775ac8" />
<img width="1062" height="487" alt="image" src="https://github.com/user-attachments/assets/4e8a2867-63d9-40ff-984e-a71950562ef3" />




### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
