### PR TITLE
[#25] 필수 약관 동의하기 api 제작

### DIFF
--- a/src/main/java/com/k_passs/backend/domain/term/controller/TermRestController.java
+++ b/src/main/java/com/k_passs/backend/domain/term/controller/TermRestController.java
@@ -1,0 +1,43 @@
+package com.k_passs.backend.domain.term.controller;
+
+import com.k_passs.backend.domain.term.dto.request.TermRequestDTO;
+import com.k_passs.backend.domain.term.dto.response.TermResponseDTO;
+import com.k_passs.backend.domain.term.service.TermService;
+import com.k_passs.backend.domain.user.entity.User;
+import com.k_passs.backend.global.common.response.BaseResponse;
+import com.k_passs.backend.global.error.code.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/term")
+@Validated
+public class TermRestController {
+    private final TermService termService;
+
+    // [추가] 약관 동의
+    @PostMapping("")
+    @Operation(summary = "회원가입 시 약관에 동의합니다.", description = "약관 ID와 동의 여부(true/false)를 배열로 POST합니다. 필수 약관 미동의 및 잘못된 약관 ID는 에러 처리됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "MEMBER_201", description = "약관 동의 처리가 성공적으로 완료되었습니다."),
+            @ApiResponse(responseCode = "MEMBER_4001", description = "존재하지 않는 약관 ID입니다."),
+            @ApiResponse(responseCode = "MEMBER_4002", description = "필수 약관에 동의하지 않았습니다."),
+    })
+    public BaseResponse<TermResponseDTO.TermAgreeResult> termAgree(
+            @AuthenticationPrincipal(expression = "user") User user,
+            @RequestBody @Valid TermRequestDTO.TermAgreeRequest request
+    ) {
+        TermResponseDTO.TermAgreeResult result = termService.termAgree(user, request);
+        return BaseResponse.onSuccess(SuccessStatus.USER_AGREE_TERMS, result);
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/term/controller/TermRestController.java
+++ b/src/main/java/com/k_passs/backend/domain/term/controller/TermRestController.java
@@ -13,10 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,6 +21,18 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 public class TermRestController {
     private final TermService termService;
+
+    @GetMapping
+    @Operation(summary = "전체 약관 목록과 사용자의 동의 여부를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "COMMON_200", description = "약관 목록 조회가 성공적으로 완료되었습니다.")
+    })
+    public BaseResponse<TermResponseDTO.GetAgreeResult> getAllTerms(
+            @AuthenticationPrincipal(expression = "user") User user
+    ) {
+        TermResponseDTO.GetAgreeResult result = termService.getAllTerms(user);
+        return BaseResponse.onSuccess(SuccessStatus.OK, result);
+    }
 
     // [추가] 약관 동의
     @PostMapping("")

--- a/src/main/java/com/k_passs/backend/domain/term/converter/TermConverter.java
+++ b/src/main/java/com/k_passs/backend/domain/term/converter/TermConverter.java
@@ -1,0 +1,31 @@
+package com.k_passs.backend.domain.term.converter;
+
+import com.k_passs.backend.domain.term.dto.request.TermRequestDTO;
+import com.k_passs.backend.domain.term.dto.response.TermResponseDTO;
+
+import java.util.List;
+
+public class TermConverter {
+    /**
+     * 약관 동의 요청 DTO를 응답 DTO로 변환
+     * @param userId 동의를 처리한 사용자 ID
+     * @param request 약관 동의 요청 목록
+     * @return 약관 동의 처리 결과를 포함하는 응답 DTO
+     */
+    public static TermResponseDTO.TermAgreeResult toTermAgreeResult(
+            Long userId,
+            TermRequestDTO.TermAgreeRequest request
+    ) {
+        List<TermResponseDTO.TermAgreementResult> results = request.getTerms().stream()
+                .map(term -> TermResponseDTO.TermAgreementResult.builder()
+                        .termId(term.getTermId())
+                        .agreed(term.getAgreed())
+                        .build())
+                .toList();
+
+        return TermResponseDTO.TermAgreeResult.builder()
+                .userId(userId)
+                .terms(results)
+                .build();
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/term/converter/TermConverter.java
+++ b/src/main/java/com/k_passs/backend/domain/term/converter/TermConverter.java
@@ -2,16 +2,32 @@ package com.k_passs.backend.domain.term.converter;
 
 import com.k_passs.backend.domain.term.dto.request.TermRequestDTO;
 import com.k_passs.backend.domain.term.dto.response.TermResponseDTO;
+import com.k_passs.backend.domain.term.entity.Term;
 
 import java.util.List;
+import java.util.Map;
 
 public class TermConverter {
-    /**
-     * 약관 동의 요청 DTO를 응답 DTO로 변환
-     * @param userId 동의를 처리한 사용자 ID
-     * @param request 약관 동의 요청 목록
-     * @return 약관 동의 처리 결과를 포함하는 응답 DTO
-     */
+
+    public static TermResponseDTO.GetAgreeResult toGetAllTermsResult(
+            List<Term> allTerms,
+            Map<Integer, Boolean> userAgreements
+    ) {
+        List<TermResponseDTO.AllAgreement> results = allTerms.stream()
+                .map(term -> TermResponseDTO.AllAgreement.builder()
+                        .termId(term.getId())
+                        .title(term.getTitle())
+                        .content(term.getContent())
+                        // 동의 정보가 Map에 없으면 (즉, 한 번도 동의/비동의 기록이 없으면) false로 간주
+                        .agreed(userAgreements.getOrDefault(term.getId(), false))
+                        .build())
+                .toList();
+
+        return TermResponseDTO.GetAgreeResult.builder()
+                .terms(results)
+                .build();
+    }
+
     public static TermResponseDTO.TermAgreeResult toTermAgreeResult(
             Long userId,
             TermRequestDTO.TermAgreeRequest request

--- a/src/main/java/com/k_passs/backend/domain/term/dto/request/TermRequestDTO.java
+++ b/src/main/java/com/k_passs/backend/domain/term/dto/request/TermRequestDTO.java
@@ -1,0 +1,39 @@
+package com.k_passs.backend.domain.term.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class TermRequestDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TermAgreeRequest {
+        @Valid
+        @NotEmpty(message = "약관 목록을 포함해야 합니다.")
+        private List<TermAgreement> terms;
+    }
+
+    /**
+     * 개별 약관 동의 정보
+     */
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TermAgreement {
+        @NotNull(message = "termId는 필수입니다.")
+        private Integer termId;
+
+        @NotNull(message = "agreed 여부는 필수입니다.")
+        private Boolean agreed;
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/term/dto/response/TermResponseDTO.java
+++ b/src/main/java/com/k_passs/backend/domain/term/dto/response/TermResponseDTO.java
@@ -5,9 +5,32 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class TermResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetAgreeResult {
+        private List<AllAgreement> terms;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AllAgreement {
+        private Integer termId;
+        private String title;
+        private String content;
+        private Boolean agreed;
+    }
+
+
+
     @Builder
     @Getter
     @NoArgsConstructor

--- a/src/main/java/com/k_passs/backend/domain/term/dto/response/TermResponseDTO.java
+++ b/src/main/java/com/k_passs/backend/domain/term/dto/response/TermResponseDTO.java
@@ -1,0 +1,31 @@
+package com.k_passs.backend.domain.term.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class TermResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TermAgreeResult {
+        private Long userId;
+        private List<TermAgreementResult> terms;
+    }
+
+    /**
+     * 개별 약관 동의 결과
+     */
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TermAgreementResult {
+        private Integer termId;
+        private Boolean agreed;
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/term/entity/Term.java
+++ b/src/main/java/com/k_passs/backend/domain/term/entity/Term.java
@@ -1,0 +1,32 @@
+package com.k_passs.backend.domain.term.entity;
+
+import com.k_passs.backend.domain.model.entity.BaseEntity;
+import com.k_passs.backend.domain.tip.entity.Tip;
+import com.k_passs.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "terms")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Term extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false, length = 100)
+    private String title; // 약관 제목
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content; // 약관 내용
+
+    @Column(nullable = false)
+    private Boolean isRequired; // 필수 동의 여부
+
+    @Column(nullable = false)
+    private Integer version; // 약관 버전
+}

--- a/src/main/java/com/k_passs/backend/domain/term/entity/TermRepository.java
+++ b/src/main/java/com/k_passs/backend/domain/term/entity/TermRepository.java
@@ -1,0 +1,23 @@
+package com.k_passs.backend.domain.term.entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 서비스 약관 엔티티를 관리하는 Repository
+ */
+public interface TermRepository extends JpaRepository<Term, Integer> { // Integer는 Term의 ID 타입
+
+    // 모든 필수 약관을 조회
+    List<Term> findByIsRequired(Boolean isRequired);
+
+    // 주어진 ID 목록에 해당하는 모든 약관을 조회
+    List<Term> findByIdIn(Set<Integer> termIds);
+
+    // 특정 ID 목록과 필수 여부가 일치하는 약관들을 조회
+    @Query("SELECT t.id FROM Term t WHERE t.isRequired = TRUE")
+    Set<Integer> findAllRequiredTermIds();
+}

--- a/src/main/java/com/k_passs/backend/domain/term/entity/UserTerm.java
+++ b/src/main/java/com/k_passs/backend/domain/term/entity/UserTerm.java
@@ -36,4 +36,8 @@ public class UserTerm extends BaseEntity {
         this.term = term;
         this.agreed = agreed;
     }
+
+    public void updateAgreed(Boolean agreed) {
+        this.agreed = agreed;
+    }
 }

--- a/src/main/java/com/k_passs/backend/domain/term/entity/UserTerm.java
+++ b/src/main/java/com/k_passs/backend/domain/term/entity/UserTerm.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 import jakarta.persistence.Id;
 
 @Entity
-@Table(name = "user_terms")
+@Table(name = "user_terms", uniqueConstraints = {@UniqueConstraint(columnNames = {"user_id", "term_id"})})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserTerm extends BaseEntity {

--- a/src/main/java/com/k_passs/backend/domain/term/entity/UserTerm.java
+++ b/src/main/java/com/k_passs/backend/domain/term/entity/UserTerm.java
@@ -1,0 +1,39 @@
+package com.k_passs.backend.domain.term.entity;
+
+import com.k_passs.backend.domain.model.entity.BaseEntity;
+import com.k_passs.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import jakarta.persistence.Id;
+
+@Entity
+@Table(name = "user_terms")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserTerm extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "term_id", nullable = false)
+    private Term term; // 동의한 약관
+
+    @Column(nullable = false)
+    private Boolean agreed;
+
+    @Builder
+    public UserTerm(User user, Term term, Boolean agreed) {
+        this.user = user;
+        this.term = term;
+        this.agreed = agreed;
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/term/entity/UserTermRepository.java
+++ b/src/main/java/com/k_passs/backend/domain/term/entity/UserTermRepository.java
@@ -2,6 +2,8 @@ package com.k_passs.backend.domain.term.entity;
 
 import com.k_passs.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -9,6 +11,8 @@ import java.util.Optional;
  */
 public interface UserTermRepository extends JpaRepository<UserTerm, Long> {
     Optional<UserTerm> findByUserAndTerm(User user, Term term);
+
+    List<UserTerm> findByUser(User user);
 
     void deleteByUser(User user);
 }

--- a/src/main/java/com/k_passs/backend/domain/term/entity/UserTermRepository.java
+++ b/src/main/java/com/k_passs/backend/domain/term/entity/UserTermRepository.java
@@ -1,0 +1,14 @@
+package com.k_passs.backend.domain.term.entity;
+
+import com.k_passs.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+/**
+ * 사용자의 약관 동의 상태를 관리하는 Repository
+ */
+public interface UserTermRepository extends JpaRepository<UserTerm, Long> {
+    Optional<UserTerm> findByUserAndTerm(User user, Term term);
+
+    void deleteByUser(User user);
+}

--- a/src/main/java/com/k_passs/backend/domain/term/service/TermService.java
+++ b/src/main/java/com/k_passs/backend/domain/term/service/TermService.java
@@ -1,0 +1,9 @@
+package com.k_passs.backend.domain.term.service;
+
+import com.k_passs.backend.domain.term.dto.request.TermRequestDTO;
+import com.k_passs.backend.domain.term.dto.response.TermResponseDTO;
+import com.k_passs.backend.domain.user.entity.User;
+
+public interface TermService {
+    TermResponseDTO.TermAgreeResult termAgree(User user, TermRequestDTO.TermAgreeRequest request);
+}

--- a/src/main/java/com/k_passs/backend/domain/term/service/TermService.java
+++ b/src/main/java/com/k_passs/backend/domain/term/service/TermService.java
@@ -5,5 +5,7 @@ import com.k_passs.backend.domain.term.dto.response.TermResponseDTO;
 import com.k_passs.backend.domain.user.entity.User;
 
 public interface TermService {
+    TermResponseDTO.GetAgreeResult getAllTerms(User user);
+
     TermResponseDTO.TermAgreeResult termAgree(User user, TermRequestDTO.TermAgreeRequest request);
 }

--- a/src/main/java/com/k_passs/backend/domain/term/service/TermServiceImpl.java
+++ b/src/main/java/com/k_passs/backend/domain/term/service/TermServiceImpl.java
@@ -1,0 +1,83 @@
+package com.k_passs.backend.domain.term.service;
+
+import com.k_passs.backend.domain.term.converter.TermConverter;
+import com.k_passs.backend.domain.term.dto.request.TermRequestDTO;
+import com.k_passs.backend.domain.term.dto.response.TermResponseDTO;
+import com.k_passs.backend.domain.term.entity.Term;
+import com.k_passs.backend.domain.term.entity.TermRepository;
+import com.k_passs.backend.domain.term.entity.UserTerm;
+import com.k_passs.backend.domain.term.entity.UserTermRepository;
+import com.k_passs.backend.domain.user.entity.User;
+import com.k_passs.backend.global.error.code.status.ErrorStatus;
+import com.k_passs.backend.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TermServiceImpl implements TermService{
+
+    private final TermRepository termRepository; // 약관 Repository
+    private final UserTermRepository userTermRepository; // 사용자 약관 Repository
+
+    @Override
+    @Transactional
+    public TermResponseDTO.TermAgreeResult termAgree(User user, TermRequestDTO.TermAgreeRequest request) {
+        Set<Integer> receivedTermIds = request.getTerms().stream()
+                .map(TermRequestDTO.TermAgreement::getTermId)
+                .collect(Collectors.toSet());
+
+        // 1. 필수 약관 ID 목록을 DB에서 조회
+        Set<Integer> requiredTermIds = termRepository.findAllRequiredTermIds();
+
+        // 2. 요청된 모든 약관을 DB에서 조회하여 Map 형태로 변환 (ID -> Term 엔티티)
+        Map<Integer, Term> allTerms = termRepository.findByIdIn(receivedTermIds).stream()
+                .collect(Collectors.toMap(Term::getId, Function.identity()));
+
+        // 3. 존재하지 않는 약관 ID 검증
+        if (allTerms.size() != receivedTermIds.size()) {
+            // 요청된 ID 개수와 조회된 Term 엔티티 개수가 다르면, 존재하지 않는 약관 ID가 포함됨
+            throw new GeneralException(ErrorStatus.TERM_NOT_FOUND);
+        }
+
+        // 4. 필수 약관 동의 여부 검증 및 누락된 필수 약관 체크
+        for (Integer requiredId : requiredTermIds) {
+            // 필수 약관이 요청에 포함되었는지, 그리고 동의했는지 확인
+            boolean isAgreed = request.getTerms().stream()
+                    .filter(termReq -> termReq.getTermId().equals(requiredId))
+                    .findFirst()
+                    .map(TermRequestDTO.TermAgreement::getAgreed)
+                    .orElse(false); // 요청에 포함되지 않았으면 동의하지 않은 것으로 간주
+
+            if (!isAgreed) {
+                // 필수 약관 미동의 또는 누락 시 에러
+                throw new GeneralException(ErrorStatus.REQUIRED_TERM_NOT_AGREED);
+            }
+        }
+
+        // 5. 약관 동의 정보 저장 로직
+        List<UserTerm> userTermsToSave = request.getTerms().stream()
+                .map(termReq -> {
+                    Term term = allTerms.get(termReq.getTermId());
+
+                    return UserTerm.builder()
+                            .user(user)
+                            .term(term)
+                            .agreed(termReq.getAgreed())
+                            .build();
+                })
+                .toList();
+
+        userTermRepository.saveAll(userTermsToSave);
+
+        // 6. 응답 DTO 변환 및 반환
+        return TermConverter.toTermAgreeResult(user.getId(), request);
+    }
+}

--- a/src/main/java/com/k_passs/backend/domain/term/service/TermServiceImpl.java
+++ b/src/main/java/com/k_passs/backend/domain/term/service/TermServiceImpl.java
@@ -27,6 +27,28 @@ public class TermServiceImpl implements TermService{
     private final TermRepository termRepository; // 약관 Repository
     private final UserTermRepository userTermRepository; // 사용자 약관 Repository
 
+    // [추가] 전체 약관 목록 및 사용자 동의 여부 조회
+    @Override
+    @Transactional(readOnly = true)
+    public TermResponseDTO.GetAgreeResult getAllTerms(User user) {
+        // 1. 모든 약관(Term) 목록 조회
+        List<Term> allTerms = termRepository.findAll();
+
+        // 2. 해당 사용자의 모든 약관 동의 정보(UserTerm) 조회
+        // (가정: UserTermRepository에 findByUser(User user) 메소드가 존재)
+        List<UserTerm> userTerms = userTermRepository.findByUser(user);
+
+        // 3. UserTerm 리스트를 Map<Term ID, Agreed Status> 형태로 변환 (조회 효율을 위해)
+        Map<Integer, Boolean> userAgreements = userTerms.stream()
+                .collect(Collectors.toMap(
+                        userTerm -> userTerm.getTerm().getId(), // UserTerm.term.id
+                        UserTerm::getAgreed // UserTerm.agreed
+                ));
+
+        // 4. Converter를 사용하여 응답 DTO로 변환
+        return TermConverter.toGetAllTermsResult(allTerms, userAgreements);
+    }
+
     @Override
     @Transactional
     public TermResponseDTO.TermAgreeResult termAgree(User user, TermRequestDTO.TermAgreeRequest request) {

--- a/src/main/java/com/k_passs/backend/domain/term/service/TermServiceImpl.java
+++ b/src/main/java/com/k_passs/backend/domain/term/service/TermServiceImpl.java
@@ -69,17 +69,18 @@ public class TermServiceImpl implements TermService{
         }
 
         // 필수 약관 동의 여부 검증
-        for (Integer requiredId : requiredTermIds) {
-            boolean isAgreed = request.getTerms().stream()
-                    .filter(termReq -> termReq.getTermId().equals(requiredId))
-                    .findFirst()
-                    .map(TermRequestDTO.TermAgreement::getAgreed)
-                    .orElse(false);
+        Map<Integer, Boolean> receivedAgreements = request.getTerms().stream()
+                .collect(Collectors.toMap(
+                        TermRequestDTO.TermAgreement::getTermId,
+                        TermRequestDTO.TermAgreement::getAgreed
+                ));
 
-            if (!isAgreed) throw new GeneralException(ErrorStatus.REQUIRED_TERM_NOT_AGREED);
+        for (Integer requiredId : requiredTermIds) {
+            if (!receivedAgreements.getOrDefault(requiredId, false)) {
+                throw new GeneralException(ErrorStatus.REQUIRED_TERM_NOT_AGREED);
+            }
         }
 
-        // ✅ Upsert 로직: 기존 데이터 있으면 update, 없으면 insert
         for (TermRequestDTO.TermAgreement termReq : request.getTerms()) {
             Term term = allTerms.get(termReq.getTermId());
 

--- a/src/main/java/com/k_passs/backend/domain/term/service/TermServiceImpl.java
+++ b/src/main/java/com/k_passs/backend/domain/term/service/TermServiceImpl.java
@@ -56,50 +56,51 @@ public class TermServiceImpl implements TermService{
                 .map(TermRequestDTO.TermAgreement::getTermId)
                 .collect(Collectors.toSet());
 
-        // 1. 필수 약관 ID 목록을 DB에서 조회
+        // 필수 약관 ID 목록 조회
         Set<Integer> requiredTermIds = termRepository.findAllRequiredTermIds();
 
-        // 2. 요청된 모든 약관을 DB에서 조회하여 Map 형태로 변환 (ID -> Term 엔티티)
+        // 요청된 약관들을 DB에서 조회 (ID → Term)
         Map<Integer, Term> allTerms = termRepository.findByIdIn(receivedTermIds).stream()
                 .collect(Collectors.toMap(Term::getId, Function.identity()));
 
-        // 3. 존재하지 않는 약관 ID 검증
+        // 존재하지 않는 약관 검증
         if (allTerms.size() != receivedTermIds.size()) {
-            // 요청된 ID 개수와 조회된 Term 엔티티 개수가 다르면, 존재하지 않는 약관 ID가 포함됨
             throw new GeneralException(ErrorStatus.TERM_NOT_FOUND);
         }
 
-        // 4. 필수 약관 동의 여부 검증 및 누락된 필수 약관 체크
+        // 필수 약관 동의 여부 검증
         for (Integer requiredId : requiredTermIds) {
-            // 필수 약관이 요청에 포함되었는지, 그리고 동의했는지 확인
             boolean isAgreed = request.getTerms().stream()
                     .filter(termReq -> termReq.getTermId().equals(requiredId))
                     .findFirst()
                     .map(TermRequestDTO.TermAgreement::getAgreed)
-                    .orElse(false); // 요청에 포함되지 않았으면 동의하지 않은 것으로 간주
+                    .orElse(false);
 
-            if (!isAgreed) {
-                // 필수 약관 미동의 또는 누락 시 에러
-                throw new GeneralException(ErrorStatus.REQUIRED_TERM_NOT_AGREED);
-            }
+            if (!isAgreed) throw new GeneralException(ErrorStatus.REQUIRED_TERM_NOT_AGREED);
         }
 
-        // 5. 약관 동의 정보 저장 로직
-        List<UserTerm> userTermsToSave = request.getTerms().stream()
-                .map(termReq -> {
-                    Term term = allTerms.get(termReq.getTermId());
+        // ✅ Upsert 로직: 기존 데이터 있으면 update, 없으면 insert
+        for (TermRequestDTO.TermAgreement termReq : request.getTerms()) {
+            Term term = allTerms.get(termReq.getTermId());
 
-                    return UserTerm.builder()
-                            .user(user)
-                            .term(term)
-                            .agreed(termReq.getAgreed())
-                            .build();
-                })
-                .toList();
+            userTermRepository.findByUserAndTerm(user, term)
+                    .ifPresentOrElse(
+                            existing -> {
+                                // 이미 존재하면 동의 상태만 갱신
+                                existing.updateAgreed(termReq.getAgreed());
+                            },
+                            () -> {
+                                // 없으면 새로 생성
+                                UserTerm newUserTerm = UserTerm.builder()
+                                        .user(user)
+                                        .term(term)
+                                        .agreed(termReq.getAgreed())
+                                        .build();
+                                userTermRepository.save(newUserTerm);
+                            }
+                    );
+        }
 
-        userTermRepository.saveAll(userTermsToSave);
-
-        // 6. 응답 DTO 변환 및 반환
         return TermConverter.toTermAgreeResult(user.getId(), request);
     }
 }

--- a/src/main/java/com/k_passs/backend/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/k_passs/backend/global/error/code/status/ErrorStatus.java
@@ -22,6 +22,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     ///  User 에러
     NO_SUCH_USER(HttpStatus.BAD_REQUEST,"USER_404","유저가 존재하지 않습니다."),
+
+    // [추가] 약관 에러
+    TERM_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER_4001", "존재하지 않는 약관 ID입니다."),
+    REQUIRED_TERM_NOT_AGREED(HttpStatus.BAD_REQUEST, "MEMBER_4002", "필수 약관에 동의하지 않았습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/k_passs/backend/global/error/code/status/SuccessStatus.java
+++ b/src/main/java/com/k_passs/backend/global/error/code/status/SuccessStatus.java
@@ -25,7 +25,10 @@ public enum SuccessStatus implements BaseCode {
     USER_GET_SUCCESS(HttpStatus.OK,"USER_200","회원 정보 조회가 성공적으로 조회되었습니다."),
     USER_UPDATE_NAME(HttpStatus.CREATED, "USER_201","회원 닉네임 수정이 성공적으로 수정되었습니다."),
     USER_GET_TIPS(HttpStatus.OK, "USER_202", "회원이 찜한 꿀팁이 조회되었습니다."),
-    USER_GET_CHALLENGE(HttpStatus.OK,"USER_203","회원이 완료한 챌린지가 조회되었습니다.")
+    USER_GET_CHALLENGE(HttpStatus.OK,"USER_203","회원이 완료한 챌린지가 조회되었습니다."),
+
+    // Term
+    USER_AGREE_TERMS(HttpStatus.CREATED, "MEMBER_201", "성공적으로 생성되었습니다.")
     ;
 
 

--- a/src/main/java/com/k_passs/backend/global/error/code/status/SuccessStatus.java
+++ b/src/main/java/com/k_passs/backend/global/error/code/status/SuccessStatus.java
@@ -28,7 +28,7 @@ public enum SuccessStatus implements BaseCode {
     USER_GET_CHALLENGE(HttpStatus.OK,"USER_203","회원이 완료한 챌린지가 조회되었습니다."),
 
     // Term
-    USER_AGREE_TERMS(HttpStatus.CREATED, "MEMBER_201", "성공적으로 생성되었습니다.")
+    USER_AGREE_TERMS(HttpStatus.CREATED, "MEMBER_201", "약관 동의 처리가 성공적으로 완료되었습니다.")
     ;
 
 

--- a/src/main/java/com/k_passs/backend/global/security/CustomUserDetails.java
+++ b/src/main/java/com/k_passs/backend/global/security/CustomUserDetails.java
@@ -1,26 +1,29 @@
 package com.k_passs.backend.global.security;
 
+import com.k_passs.backend.domain.user.entity.User; // User 엔티티 import
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
 
-@Getter // Lombok을 사용하여 getUserId() 메소드를 자동으로 생성
+@Getter // Lombok을 사용하여 getUserId()와 getUser() 메소드를 자동으로 생성
 public class CustomUserDetails implements UserDetails {
 
-    // 우리 애플리케이션에서 사용할 고유한 사용자 정보
-    private final Long userId;
+    // User 엔티티 객체를 저장으로 수정
+    private final User user;
 
-    public CustomUserDetails(Long userId) {
-        this.userId = userId;
+    public CustomUserDetails(User user) {
+        this.user = user;
     }
 
-    // --- UserDetails 인터페이스의 메소드 구현 ---
+    // 편의상 userId를 반환하는 메소드 (Controller에서 @AuthenticationPrincipal 대신 사용 가능)
+    public Long getUserId() {
+        return user.getId();
+    }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        // 사용자 권한(Role) 목록을 반환하는 곳. 지금은 사용하지 않으므로 비어있는 리스트 반환.
         return java.util.Collections.emptyList();
     }
 
@@ -33,7 +36,7 @@ public class CustomUserDetails implements UserDetails {
     @Override
     public String getUsername() {
         // Spring Security에서 사용자를 식별하는 기본값. 우리 서비스의 userId를 문자열로 변환하여 반환.
-        return String.valueOf(userId);
+        return String.valueOf(user.getId());
     }
 
     // 아래 4개 메소드는 계정 상태를 관리하는 곳. 지금은 모두 true로 설정하여 항상 활성화 상태로 둡니다.

--- a/src/main/java/com/k_passs/backend/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/k_passs/backend/global/security/JwtAuthenticationFilter.java
@@ -35,8 +35,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 // ifPresent를 사용하면 null 체크를 더 깔끔하게 할 수 있습니다.
                 userRepository.findById(userId).ifPresent(user -> {
-                    // [수정] Principal로 CustomUserDetails 객체를 생성합니다.
-                    CustomUserDetails principal = new CustomUserDetails(user.getId());
+                    // Principal로 CustomUserDetails 객체를 생성할 때, User 엔티티 객체 자체를 전달.
+                    CustomUserDetails principal = new CustomUserDetails(user);
 
                     UsernamePasswordAuthenticationToken authentication =
                             new UsernamePasswordAuthenticationToken(principal, null, null); // 권한이 필요 없다면 세 번째 인자는 비워둡니다.


### PR DESCRIPTION
#25

### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #25 

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 회원가입 시, 필수 약관 동의를 체크했음을 전달하는 api를 제작했습니다.
- CustomUserDetails와 JwtAuthenticationFilter를 수정하여, 이제 JWT 토큰으로 인증된 User 엔티티 객체를 컨트롤러에서 바로 사용할 수있도록 했습니다.
- 필수약관 전체 조회 api 를 추가하였습니다

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- 약관동의 table의 경우, sql로 작성을 해놓고 연결해서 사용하는게 더 좋나요? 아니면 테이블에서 직접 추가를 하는게 더 좋나요?